### PR TITLE
[fix] rm tracing setup

### DIFF
--- a/bin/host/src/main.rs
+++ b/bin/host/src/main.rs
@@ -153,9 +153,6 @@ async fn main() -> eyre::Result<()> {
         std::env::set_var("RUST_LOG", "info");
     }
 
-    // Initialize the logger.
-    tracing_subscriber::registry().with(fmt::layer()).with(EnvFilter::from_default_env()).init();
-
     // Parse the command line arguments.
     let args = HostArgs::parse();
     let provider_config = args.provider.into_provider().await?;


### PR DESCRIPTION
It's conflicting with `run_with_metric_collection`

```
thread 'main' panicked at /home/ubuntu/.cargo/git/checkouts/afs-prototype-3548e7bd38a79451/732726a/crates/stark-sdk/src/bench/mod.rs:30:57:
called `Result::unwrap()` on an `Err` value: SetGlobalDefaultError("a global default trace dispatcher has already been set")
```