### PR TITLE
chore(ci): fix compare workflow

### DIFF
--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -66,9 +66,9 @@ jobs:
         run: |
           ls
           BASE_NAME=${{ needs.run-base-benchmark.outputs.metric_name }}
-          BASE_JSON=$BASE_NAME/$BASE_NAME.json
+          BASE_JSON=$BASE_NAME.json
           TARGET_NAME=${{ needs.run-target-benchmark.outputs.metric_name }}
-          TARGET_JSON=$TARGET_NAME/$TARGET_NAME.json
+          TARGET_JSON=$TARGET_NAME.json
 
           openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON 
           MD_PATH=${TARGET_JSON%.json}.md

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -53,20 +53,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-base-benchmark.outputs.metric_name }}
-          path: base-metric.json
+          path: base-metric
 
       - name: Download target benchmark results
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-target-benchmark.outputs.metric_name }}
-          path: target-metric.json
+          path: target-metric
 
       - name: Install openvm-prof
         run: |
           cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
       - name: Compare metrics
         run: |
-          openvm-prof --json-paths target-metric.json --prev-json-paths base-metric.json 
-          MD_PATH=target-metric.md
+          BASE_JSON=$(find base-metric -name "*.json")
+          TARGET_JSON=$(find target-metric -name "*.json")
+          openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON 
+          MD_PATH=${TARGET_JSON%.json}.md
           # Inspired by https://github.com/rustls/rustls/blob/7159373401f253cbaacd276634508e0798a8849f/.github/workflows/icount-bench.yml#L37
           cat $MD_PATH >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -4,8 +4,8 @@ on:
   workflow_dispatch:
     inputs:
       base_rev:
-        description: "Base OpenVM revision to compare"
-        required: true
+        description: "Base OpenVM revision to compare (defaults to latest main)"
+        required: false
         type: string
       target_rev:
         description: "Target OpenVM revision to compare"
@@ -23,11 +23,33 @@ on:
         default: m7a.48xlarge
 
 jobs:
+  get-base-rev:
+    runs-on: ubuntu-latest
+    outputs:
+      rev: ${{ steps.get-rev.outputs.result }}
+    steps:
+      - name: Get default base rev from main
+        id: get-rev
+        uses: actions/github-script@v6
+        with:
+          script: |
+            if ("${{ github.event.inputs.base_rev }}" !== "") {
+              return "${{ github.event.inputs.base_rev }}";
+            } else {
+              const { data } = await github.rest.repos.getCommit({
+                owner: 'openvm-org',
+                repo: 'openvm',
+                ref: 'main'
+              });
+              return data.sha;
+            }
+
   run-base-benchmark:
+    needs: get-base-rev
     name: "Run Base Benchmark"
     uses: ./.github/workflows/update-patches.yml
     with:
-      OPENVM_REV: ${{ github.event.inputs.base_rev }}
+      OPENVM_REV: ${{ needs.get-base-rev.outputs.rev }}
       run_benchmark: true
       benchmark_mode: ${{ github.event.inputs.benchmark_mode }}
       instance_family: ${{ github.event.inputs.instance_family }}

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -12,9 +12,14 @@ on:
         required: true
         type: string
       benchmark_mode:
-        description: "Benchmark mode"
-        type: string
+        type: choice
         required: false
+        description: Running mode
+        options:
+          - execute
+          - tracegen
+          - prove
+          - prove-e2e
         default: prove-e2e
       instance_family:
         description: "Instance family to use for benchmark"

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -66,8 +66,10 @@ jobs:
           cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
       - name: Compare metrics
         run: |
-          BASE_JSON=$(find base-metric -name "*.json")
-          TARGET_JSON=$(find target-metric -name "*.json")
+          ls base-metric
+          BASE_JSON=$(find base-metric -maxdepth 1 -type f -name "*.json")
+          ls target-metric
+          TARGET_JSON=$(find target-metric -maxdepth 1 -type f -name "*.json")
           openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON 
           MD_PATH=${TARGET_JSON%.json}.md
           # Inspired by https://github.com/rustls/rustls/blob/7159373401f253cbaacd276634508e0798a8849f/.github/workflows/icount-bench.yml#L37

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -23,33 +23,11 @@ on:
         default: m7a.48xlarge
 
 jobs:
-  get-base-rev:
-    runs-on: ubuntu-latest
-    outputs:
-      rev: ${{ steps.get-rev.outputs.result }}
-    steps:
-      - name: Get default base rev from main
-        id: get-rev
-        uses: actions/github-script@v6
-        with:
-          script: |
-            if ("${{ github.event.inputs.base_rev }}" !== "") {
-              return "${{ github.event.inputs.base_rev }}";
-            } else {
-              const { data } = await github.rest.repos.getCommit({
-                owner: 'openvm-org',
-                repo: 'openvm',
-                ref: 'main'
-              });
-              return data.sha;
-            }
-
   run-base-benchmark:
-    needs: get-base-rev
     name: "Run Base Benchmark"
     uses: ./.github/workflows/update-patches.yml
     with:
-      OPENVM_REV: ${{ needs.get-base-rev.outputs.rev }}
+      OPENVM_REV: ${{ github.event.inputs.base_rev }}
       run_benchmark: true
       benchmark_mode: ${{ github.event.inputs.benchmark_mode }}
       instance_family: ${{ github.event.inputs.instance_family }}

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -64,6 +64,7 @@ jobs:
           cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
       - name: Compare metrics
         run: |
+          ls
           BASE_NAME=${{ needs.run-base-benchmark.outputs.metric_name }}
           BASE_JSON=$BASE_NAME/$BASE_NAME.json
           TARGET_NAME=${{ needs.run-target-benchmark.outputs.metric_name }}

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -53,23 +53,22 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-base-benchmark.outputs.metric_name }}
-          path: base-metric
 
       - name: Download target benchmark results
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-target-benchmark.outputs.metric_name }}
-          path: target-metric
 
       - name: Install openvm-prof
         run: |
           cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
       - name: Compare metrics
         run: |
-          ls base-metric
-          BASE_JSON=$(find base-metric -maxdepth 1 -type f -name "*.json")
-          ls target-metric
-          TARGET_JSON=$(find target-metric -maxdepth 1 -type f -name "*.json")
+          BASE_NAME=${{ needs.run-base-benchmark.outputs.metric_name }}
+          BASE_JSON=$BASE_NAME/$BASE_NAME.json
+          TARGET_NAME=${{ needs.run-target-benchmark.outputs.metric_name }}
+          TARGET_JSON=$TARGET_NAME/$TARGET_NAME.json
+
           openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON 
           MD_PATH=${TARGET_JSON%.json}.md
           # Inspired by https://github.com/rustls/rustls/blob/7159373401f253cbaacd276634508e0798a8849f/.github/workflows/icount-bench.yml#L37

--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -52,23 +52,21 @@ jobs:
       - name: Download base benchmark results
         uses: actions/download-artifact@v4
         with:
-          name: metric-json
-          path: ${{ needs.run-base-benchmark.outputs.metric_path }}
+          name: ${{ needs.run-base-benchmark.outputs.metric_name }}
+          path: base-metric.json
 
       - name: Download target benchmark results
         uses: actions/download-artifact@v4
         with:
-          name: metric-json
-          path: ${{ needs.run-target-benchmark.outputs.metric_path }}
+          name: ${{ needs.run-target-benchmark.outputs.metric_name }}
+          path: target-metric.json
 
       - name: Install openvm-prof
         run: |
           cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
       - name: Compare metrics
         run: |
-          METRICS_PATH=${{ needs.run-target-benchmark.outputs.metric_path }}
-          echo "Comparing $METRICS_PATH with ${{ needs.run-target-benchmark.outputs.metric_path }}"
-          openvm-prof --json-paths $METRICS_PATH --prev-json-paths ${{ needs.run-base-benchmark.outputs.metric_path }} 
-          MD_PATH=${METRICS_PATH%.json}.md
+          openvm-prof --json-paths target-metric.json --prev-json-paths base-metric.json 
+          MD_PATH=target-metric.md
           # Inspired by https://github.com/rustls/rustls/blob/7159373401f253cbaacd276634508e0798a8849f/.github/workflows/icount-bench.yml#L37
           cat $MD_PATH >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -142,9 +142,11 @@ jobs:
       - family=${{ inputs.instance_family || github.event.inputs.instance_family }}
       - disk=large
       - tag=bench-reth-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+      - extras=s3-cache
     outputs:
       metric_name: ${{ steps.set-metric-name.outputs.name }}
     steps:
+      - uses: runs-on/action@v1
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.head_ref || github.ref }}
@@ -201,18 +203,8 @@ jobs:
           echo "METRIC_PATH=${METRIC_PATH}" >> $GITHUB_ENV
           echo "name=${METRIC_NAME}" >> $GITHUB_OUTPUT
 
-      - name: Build ELF
-        working-directory: bin/client-eth
-        run: |
-          PROFILE="release"
-          if [[ "${{ github.event.inputs.collect_metrics || inputs.collect_metrics }}" == "true" ]]; then
-            PROFILE="profiling"
-          fi
-          cargo openvm build --no-transpile --profile=$PROFILE
-          mkdir -p ../host/elf
-          cp target/riscv32im-risc0-zkvm-elf/$PROFILE/openvm-client-eth ../host/elf/
-
       - name: Run Reth
+        id: run-reth
         run: |
           mkdir -p rpc-cache
           mkdir -p .bench_metrics
@@ -222,12 +214,20 @@ jobs:
           OPTIONAL_ARGS=""
           PROFILE="maxperf"
           FEATURES="bench-metrics,nightly-features,${{ inputs.memory_allocator || github.event.inputs.memory_allocator }}"
-          RUST_LOG="info,p3_=warn"
-          if [[ "${{ inputs.collect_metrics || github.event.inputs.collect_metrics }}" == "true" ]]; then
-            OPTIONAL_ARGS="--profiling --kzg-params-dir $PARAMS_DIR"
-            PROFILE="profiling"
-            FEATURES="${FEATURES},profiling"
-          fi
+          echo "cache_key=reth-binary-${PROFILE}-${FEATURES}" >> $GITHUB_OUTPUT
+
+      - name: Cache Reth binary
+        id: cache-binary
+        uses: actions/cache@v4
+        with:
+          path: target/${{ steps.run-reth.outputs.profile }}/openvm-reth-benchmark
+          key: ${{ steps.run-reth.outputs.cache_key }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Build Reth if not cached
+        if: steps.cache-binary.outputs.cache-hit != 'true'
+        run: |
+          PROFILE="${{ steps.run-reth.outputs.profile }}"
+          FEATURES="${{ steps.run-reth.outputs.features }}"
           arch=$(uname -m)
           case $arch in
           arm64|aarch64)
@@ -237,13 +237,16 @@ jobs:
               RUSTFLAGS="-Ctarget-cpu=native -C target-feature=+avx512f"
               ;;
           *)
-          echo "Unsupported architecture: $arch"
-          exit 1
-          ;;
+              echo "Unsupported architecture: $arch"
+              exit 1
+              ;;
           esac
           export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
           RUSTFLAGS=$RUSTFLAGS cargo build --bin openvm-reth-benchmark --profile=$PROFILE --no-default-features --features=$FEATURES
-          RUST_LOG=$RUST_LOG OUTPUT_PATH=${METRIC_PATH} ./target/$PROFILE/openvm-reth-benchmark \
+
+      - name: Run benchmark
+        run: |
+          RUST_LOG=info,p3_=warn OUTPUT_PATH=${METRIC_PATH} ./target/$PROFILE/openvm-reth-benchmark \
             --$MODE --block-number $BLOCK_NUMBER --rpc-url $RPC_1 --cache-dir rpc-cache \
             --app-log-blowup ${{ inputs.app_log_blowup || github.event.inputs.app_log_blowup }} \
             --leaf-log-blowup ${{ inputs.leaf_log_blowup || github.event.inputs.leaf_log_blowup }} \

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -122,6 +122,10 @@ on:
         required: true
       BENCHER_API_TOKEN:
         required: true
+    outputs:
+      metric_name:
+        description: "Name of the metric"
+        value: ${{ jobs.run-reth.outputs.metric_name }}
 
 env:
   S3_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/results

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -178,7 +178,7 @@ jobs:
         run: |
           input_json_str="${{ toJSON(github.event.inputs || inputs) }}"
           input_hash=$(echo $input_json_str | sha256sum | cut -d' ' -f1)
-          dir_hash=$(find . -type f -exec sha256sum {} \; | sha256sum | cut -d' ' -f1)
+          dir_hash=$(git write-tree)
           echo "elf_cache_key=elf-${dir_hash}-${input_hash}" >> $GITHUB_OUTPUT
           echo "host_cache_key=host-${dir_hash}-${input_hash}" >> $GITHUB_OUTPUT
       - name: Load SSH key

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -43,9 +43,10 @@ on:
       mode:
         type: choice
         required: false
-        description: Running mode, one of execute, prove, or prove-e2e
+        description: Running mode
         options:
           - execute
+          - tracegen
           - prove
           - prove-e2e
         default: prove-e2e
@@ -103,7 +104,7 @@ on:
       mode:
         type: string
         required: false
-        description: Running mode, one of execute, prove, or prove-e2e
+        description: Running mode, one of execute, tracegen, prove, or prove-e2e
         default: prove-e2e
       collect_metrics:
         type: boolean

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -202,51 +202,80 @@ jobs:
           METRIC_PATH=".bench_metrics/${METRIC_NAME}.json"
           echo "METRIC_PATH=${METRIC_PATH}" >> $GITHUB_ENV
           echo "name=${METRIC_NAME}" >> $GITHUB_OUTPUT
+          echo "elf_cache_key=elf-${METRIC_NAME}" >> $GITHUB_OUTPUT
+          echo "host_cache_key=host-${METRIC_NAME}" >> $GITHUB_OUTPUT
 
-      - name: Run Reth
-        id: run-reth
-        run: |
-          mkdir -p rpc-cache
-          mkdir -p .bench_metrics
-          RPC_1=${{ secrets.RPC_URL_1 }}
-          MODE=${{ inputs.mode || github.event.inputs.mode }}
-          BLOCK_NUMBER=${{ inputs.block_number || github.event.inputs.block_number }}
-          OPTIONAL_ARGS=""
-          PROFILE="maxperf"
-          FEATURES="bench-metrics,nightly-features,${{ inputs.memory_allocator || github.event.inputs.memory_allocator }}"
-          echo "cache_key=reth-binary-${PROFILE}-${FEATURES}" >> $GITHUB_OUTPUT
-
-      - name: Cache Reth binary
-        id: cache-binary
-        uses: actions/cache@v4
+      - name: Restore Guest ELF from cache
+        id: cache-guest-elf
+        uses: runs-on/cache@v4
         with:
-          path: target/${{ steps.run-reth.outputs.profile }}/openvm-reth-benchmark
-          key: ${{ steps.run-reth.outputs.cache_key }}-${{ hashFiles('**/Cargo.lock') }}
+          path: host/elf/openvm-client-eth
+          key: ${{ steps.set-metric-name.outputs.elf_cache_key }}
 
-      - name: Build Reth if not cached
-        if: steps.cache-binary.outputs.cache-hit != 'true'
+      - name: Build Guest ELF
+        if: steps.cache-guest-elf.outputs.cache-hit != 'true'
+        working-directory: bin/client-eth
         run: |
-          PROFILE="${{ steps.run-reth.outputs.profile }}"
-          FEATURES="${{ steps.run-reth.outputs.features }}"
+          PROFILE="release"
+          if [[ "${{ github.event.inputs.collect_metrics || inputs.collect_metrics }}" == "true" ]]; then
+            PROFILE="profiling"
+          fi
+          cargo openvm build --no-transpile --profile=$PROFILE
+          mkdir -p ../host/elf
+          cp target/riscv32im-risc0-zkvm-elf/$PROFILE/openvm-client-eth ../host/elf/
+
+      - name: Set build args
+        id: set-build-args
+        run: |
+          PROFILE="maxperf"
+          OPTIONAL_ARGS=""
+          FEATURES="bench-metrics,nightly-features,${{ inputs.memory_allocator || github.event.inputs.memory_allocator }}"
+          if [[ "${{ inputs.collect_metrics || github.event.inputs.collect_metrics }}" == "true" ]]; then
+            OPTIONAL_ARGS="--profiling --kzg-params-dir $PARAMS_DIR"
+            PROFILE="profiling"
+            FEATURES="${FEATURES},profiling"
+          fi
+          echo "OPTIONAL_ARGS=${OPTIONAL_ARGS}" >> $GITHUB_ENV
+          echo "PROFILE=${PROFILE}" >> $GITHUB_ENV
+          echo "FEATURES=${FEATURES}" >> $GITHUB_ENV
+          echo "profile=${PROFILE}" >> $GITHUB_OUTPUT
+
+      - name: Restore Host Binary from cache
+        id: cache-host-binary
+        uses: runs-on/cache@v4
+        with:
+          path: target/${{ steps.set-build-args.outputs.profile }}/openvm-reth-benchmark
+          key: ${{ steps.set-metric-name.outputs.host_cache_key }}
+
+      - name: Build Host Binary
+        if: steps.cache-host-binary.outputs.cache-hit != 'true'
+        run: |
           arch=$(uname -m)
           case $arch in
-          arm64|aarch64)
+            arm64|aarch64)
               RUSTFLAGS="-Ctarget-cpu=native"
               ;;
-          x86_64|amd64)
+            x86_64|amd64)
               RUSTFLAGS="-Ctarget-cpu=native -C target-feature=+avx512f"
               ;;
-          *)
+            *)
               echo "Unsupported architecture: $arch"
               exit 1
               ;;
           esac
           export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
           RUSTFLAGS=$RUSTFLAGS cargo build --bin openvm-reth-benchmark --profile=$PROFILE --no-default-features --features=$FEATURES
+          echo "JEMALLOC_SYS_WITH_MALLOC_CONF=${JEMALLOC_SYS_WITH_MALLOC_CONF}" >> $GITHUB_ENV
 
       - name: Run benchmark
         run: |
-          RUST_LOG=info,p3_=warn OUTPUT_PATH=${METRIC_PATH} ./target/$PROFILE/openvm-reth-benchmark \
+          mkdir -p rpc-cache
+          mkdir -p .bench_metrics
+          RPC_1=${{ secrets.RPC_URL_1 }}
+          MODE=${{ inputs.mode || github.event.inputs.mode }}
+          BLOCK_NUMBER=${{ inputs.block_number || github.event.inputs.block_number }}
+          export JEMALLOC_SYS_WITH_MALLOC_CONF=${JEMALLOC_SYS_WITH_MALLOC_CONF}
+          RUST_LOG="info,p3_=warn" OUTPUT_PATH=${METRIC_PATH} ./target/$PROFILE/openvm-reth-benchmark \
             --$MODE --block-number $BLOCK_NUMBER --rpc-url $RPC_1 --cache-dir rpc-cache \
             --app-log-blowup ${{ inputs.app_log_blowup || github.event.inputs.app_log_blowup }} \
             --leaf-log-blowup ${{ inputs.leaf_log_blowup || github.event.inputs.leaf_log_blowup }} \
@@ -268,7 +297,7 @@ jobs:
           echo "current_sha=${current_sha}" >> $GITHUB_ENV
           s5cmd cp ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}.json
 
-      - name: Generate markdown # result path is hardcoded results.md
+      - name: Generate markdown
         run: |
           BENCHER_METRIC_PATH=bencher.json
           openvm-prof --json-paths $METRIC_PATH --output-json $BENCHER_METRIC_PATH

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -115,6 +115,10 @@ on:
         required: false
         description: Max segment length for continuations, must be larger than 524288
         default: 8388508
+      tag:
+        type: string
+        required: false
+        description: Tag for cache keys (default is commit hash)
     secrets:
       GH_ACTIONS_DEPLOY_PRIVATE_KEY:
         required: true
@@ -182,9 +186,11 @@ jobs:
         run: |
           input_json_str="${{ toJSON(github.event.inputs || inputs) }}"
           input_hash=$(echo $input_json_str | sha256sum | cut -d' ' -f1)
+          # Use inputs.tag if defined, otherwise use current commit SHA
+          TAG="${{ inputs.tag || env.current_sha }}"
           dir_hash=$(git write-tree)
-          echo "elf_cache_key=elf-${dir_hash}-${input_hash}" >> $GITHUB_OUTPUT
-          echo "host_cache_key=host-${dir_hash}-${input_hash}" >> $GITHUB_OUTPUT
+          echo "elf_cache_key=elf-${TAG}-${input_hash}" >> $GITHUB_OUTPUT
+          echo "host_cache_key=host-${TAG}-${input_hash}" >> $GITHUB_OUTPUT
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -187,9 +187,6 @@ jobs:
           ssh-private-key: |
             ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
 
-      - name: Install cargo-openvm
-        run: |
-          cargo install --git https://github.com/openvm-org/openvm.git --force cargo-openvm
       - name: Install openvm-prof
         run: |
           cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
@@ -217,6 +214,10 @@ jobs:
           path: host/elf/openvm-client-eth
           key: ${{ steps.set-cache-keys.outputs.elf_cache_key }}
 
+      - name: Install cargo-openvm
+        if: steps.cache-guest-elf.outputs.cache-hit != 'true'
+        run: |
+          cargo install --git https://github.com/openvm-org/openvm.git --force cargo-openvm
       - name: Build Guest ELF
         if: steps.cache-guest-elf.outputs.cache-hit != 'true'
         working-directory: bin/client-eth

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -165,10 +165,10 @@ jobs:
           cache-on-failure: true
       - name: Display workflow inputs
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "${{ toJSON(github.event.inputs) }}"
-          else
+          if [[ "${{ inputs.manual_call }}" == "true" ]]; then
             echo "${{ toJSON(inputs) }}"
+          else
+            echo "${{ toJSON(github.event.inputs) }}"
           fi
       - name: Get current commit hash
         run: echo "current_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -161,6 +161,26 @@ jobs:
           else
             echo "${{ toJSON(inputs) }}"
           fi
+      - name: Get current commit hash
+        run: echo "current_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
+      - name: Set metric name
+        id: set-metric-name
+        run: |
+          input_json_str="${{ toJSON(github.event.inputs || inputs) }}"
+          input_hash=$(echo $input_json_str | sha256sum | cut -d' ' -f1)
+          METRIC_NAME=reth-$current_sha-${input_hash}
+          echo "METRIC_NAME=${METRIC_NAME}" >> $GITHUB_ENV
+          METRIC_PATH=".bench_metrics/${METRIC_NAME}.json"
+          echo "METRIC_PATH=${METRIC_PATH}" >> $GITHUB_ENV
+          echo "name=${METRIC_NAME}" >> $GITHUB_OUTPUT
+      - name: Set cache keys
+        id: set-cache-keys
+        run: |
+          input_json_str="${{ toJSON(github.event.inputs || inputs) }}"
+          input_hash=$(echo $input_json_str | sha256sum | cut -d' ' -f1)
+          dir_hash=$(find . -type f -exec sha256sum {} \; | sha256sum | cut -d' ' -f1)
+          echo "elf_cache_key=elf-${dir_hash}-${input_hash}" >> $GITHUB_OUTPUT
+          echo "host_cache_key=host-${dir_hash}-${input_hash}" >> $GITHUB_OUTPUT
       - name: Load SSH key
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -190,27 +210,12 @@ jobs:
           PARAMS_DIR=$(pwd)/params
           echo "PARAMS_DIR=$PARAMS_DIR" >> $GITHUB_ENV
 
-      - name: Get current commit hash
-        run: echo "current_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
-      - name: Set metric name
-        id: set-metric-name
-        run: |
-          input_json_str="${{ toJSON(github.event.inputs) }}"
-          input_hash=$(echo $input_json_str | sha256sum | cut -d' ' -f1)
-          METRIC_NAME=reth-$current_sha-${input_hash}
-          echo "METRIC_NAME=${METRIC_NAME}" >> $GITHUB_ENV
-          METRIC_PATH=".bench_metrics/${METRIC_NAME}.json"
-          echo "METRIC_PATH=${METRIC_PATH}" >> $GITHUB_ENV
-          echo "name=${METRIC_NAME}" >> $GITHUB_OUTPUT
-          echo "elf_cache_key=elf-${METRIC_NAME}" >> $GITHUB_OUTPUT
-          echo "host_cache_key=host-${METRIC_NAME}" >> $GITHUB_OUTPUT
-
       - name: Restore Guest ELF from cache
         id: cache-guest-elf
         uses: runs-on/cache@v4
         with:
           path: host/elf/openvm-client-eth
-          key: ${{ steps.set-metric-name.outputs.elf_cache_key }}
+          key: ${{ steps.set-cache-keys.outputs.elf_cache_key }}
 
       - name: Build Guest ELF
         if: steps.cache-guest-elf.outputs.cache-hit != 'true'
@@ -245,7 +250,7 @@ jobs:
         uses: runs-on/cache@v4
         with:
           path: target/${{ steps.set-build-args.outputs.profile }}/openvm-reth-benchmark
-          key: ${{ steps.set-metric-name.outputs.host_cache_key }}
+          key: ${{ steps.set-cache-keys.outputs.host_cache_key }}
 
       - name: Build Host Binary
         if: steps.cache-host-binary.outputs.cache-hit != 'true'

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -143,7 +143,7 @@ jobs:
       - disk=large
       - tag=bench-reth-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     outputs:
-      metric_path: ${{ steps.set-metric-path.outputs.path }}
+      metric_name: ${{ steps.set-metric-name.outputs.name }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -191,7 +191,7 @@ jobs:
       - name: Get current commit hash
         run: echo "current_sha=$(git rev-parse HEAD)" >> $GITHUB_ENV
       - name: Set metric name
-        id: set-metric-path
+        id: set-metric-name
         run: |
           input_json_str="${{ toJSON(github.event.inputs) }}"
           input_hash=$(echo $input_json_str | sha256sum | cut -d' ' -f1)
@@ -199,7 +199,7 @@ jobs:
           echo "METRIC_NAME=${METRIC_NAME}" >> $GITHUB_ENV
           METRIC_PATH=".bench_metrics/${METRIC_NAME}.json"
           echo "METRIC_PATH=${METRIC_PATH}" >> $GITHUB_ENV
-          echo "path=${METRIC_PATH}" >> $GITHUB_OUTPUT
+          echo "name=${METRIC_NAME}" >> $GITHUB_OUTPUT
 
       - name: Build ELF
         working-directory: bin/client-eth
@@ -251,10 +251,11 @@ jobs:
             --max-segment-length ${{ inputs.max_segment_length || github.event.inputs.max_segment_length }} $OPTIONAL_ARGS
 
       - name: Upload metric file
+        id: upload-metric-artifact
         uses: actions/upload-artifact@v4
         with:
-          name: metric-json
-          path: ${{ steps.set-metric-path.outputs.path }}
+          name: ${{ steps.set-metric-name.outputs.name }}
+          path: ${{ env.METRIC_PATH }}
           retention-days: 1
 
       - name: Upload Benchmark Metrics

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -61,7 +61,7 @@ on:
     outputs:
       metric_name:
         description: "Name of the metric"
-        value: ${{ jobs.run-benchmark.outputs.metric_name }}
+        value: ${{ jobs.run-benchmark && jobs.run-benchmark.outputs.metric_name || '' }}
 
 jobs:
   update-config:
@@ -192,6 +192,14 @@ jobs:
       GH_ACTIONS_DEPLOY_PRIVATE_KEY: ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
       RPC_URL_1: ${{ secrets.RPC_URL_1 }}
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
+
+  debug-outputs:
+    needs: run-benchmark
+    runs-on: ubuntu-latest
+    steps:
+      - name: Debug benchmark outputs
+        run: |
+          echo "Debug: Benchmark metric name: ${{ needs.run-benchmark.outputs.metric_name }}"
 
   close-pr:
     needs: [update-config, run-benchmark]

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -51,6 +51,12 @@ on:
         required: false
         description: "Instance family to use for benchmark"
         default: m7a.48xlarge
+      # https://github.com/actions/runner/discussions/1884
+      manual_call:
+        description: "To distinguish workflow_call from workflow_dispatch"
+        type: boolean
+        required: false
+        default: true
     secrets:
       GH_ACTIONS_DEPLOY_PRIVATE_KEY:
         required: true
@@ -61,7 +67,7 @@ on:
     outputs:
       metric_name:
         description: "Name of the metric"
-        value: ${{ jobs.run-benchmark && jobs.run-benchmark.outputs.metric_name || '' }}
+        value: ${{ jobs.run-benchmark.outputs.metric_name }}
 
 jobs:
   update-config:
@@ -71,6 +77,7 @@ jobs:
     outputs:
       branch_name: ${{ steps.create-branch.outputs.branch_name }}
       pr_number: ${{ steps.create-pr.outputs.pr_number }}
+      tag: ${{ steps.set-tag.outputs.tag }}
     steps:
       - name: Check out the repository
         uses: actions/checkout@v4
@@ -165,9 +172,13 @@ jobs:
           git commit -m "Patch openvm commits in .cargo/config.toml"
           git push -f origin "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
-
+          echo "${{ github.event_name }}"
+      - name: Set tag
+        run: |
+          CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -f1)
+          echo "tag=$(git rev-parse HEAD)-${CARGO_LOCK_HASH}" >> $GITHUB_OUTPUT
       - name: Create pull request
-        if: ${{ github.event.inputs != null }}
+        if: ${{ !inputs.manual_call }}
         uses: repo-sync/pull-request@v2
         id: create-pr
         with:
@@ -188,22 +199,15 @@ jobs:
       mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode }}
       instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family }}
       ref: ${{ needs.update-config.outputs.branch_name }}
+      tag: ${{ needs.update-config.outputs.tag }}
     secrets:
       GH_ACTIONS_DEPLOY_PRIVATE_KEY: ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}
       RPC_URL_1: ${{ secrets.RPC_URL_1 }}
       BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
 
-  debug-outputs:
-    needs: run-benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug benchmark outputs
-        run: |
-          echo "Debug: Benchmark metric name: ${{ needs.run-benchmark.outputs.metric_name }}"
-
   close-pr:
     needs: [update-config, run-benchmark]
-    if: ${{ github.event.inputs != null }}
+    if: ${{ !inputs.manual_call }}
     runs-on: ubuntu-latest
     steps:
       - name: Close PR

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -152,7 +152,7 @@ jobs:
           if [ "${{ github.event_name == 'schedule' }}" = "true" ]; then
             BRANCH_NAME="nightly"
           else
-            BRANCH_NAME="patch-openvm-$(date +%Y%m%d%H%M%S)"
+            BRANCH_NAME="patch-openvm-$(date +%Y%m%d%H%M%S)-${{ github.run_id }}-${{ github.run_attempt }}"
           fi
           # Delete local branch if it exists
           git branch -D "$BRANCH_NAME" 2>/dev/null || true

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -183,11 +183,11 @@ jobs:
 
   run-benchmark:
     needs: update-config
-    if: ${{ github.event.inputs.run_benchmark == 'true' || github.event_name == 'schedule' }}
+    if: ${{ github.event.inputs.run_benchmark == 'true' || github.event_name == 'schedule' || inputs.run_benchmark == 'true' }}
     uses: ./.github/workflows/reth-benchmark.yml
     with:
-      mode: ${{ github.event.inputs.benchmark_mode || 'prove-e2e' }}
-      instance_family: ${{ github.event.inputs.instance_family || 'm7a.48xlarge' }}
+      mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode }}
+      instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family }}
       ref: ${{ needs.update-config.outputs.branch_name }}
     secrets:
       GH_ACTIONS_DEPLOY_PRIVATE_KEY: ${{ secrets.GH_ACTIONS_DEPLOY_PRIVATE_KEY }}

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const inputRef = inputs.STARK_BACKEND_REV || github.event.inputs.STARK_BACKEND_REV;
+            const inputRef = context.inputs?.STARK_BACKEND_REV || github.event.inputs?.STARK_BACKEND_REV;
             if (inputRef && inputRef.trim()) {
               return inputRef;
             } else {
@@ -97,7 +97,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const inputRef = inputs.OPENVM_REV || github.event.inputs.OPENVM_REV;
+            const inputRef = context.inputs?.OPENVM_REV || github.event.inputs?.OPENVM_REV;
             if (inputRef && inputRef.trim()) {
               return inputRef;
             } else {

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const inputRef = ${{ inputs.STARK_BACKEND_REV }} || "${{ github.event.inputs.STARK_BACKEND_REV }}";
+            const inputRef = "${{ inputs.STARK_BACKEND_REV || github.event.inputs.STARK_BACKEND_REV }}";
             if (inputRef && inputRef.trim()) {
               return inputRef;
             } else {
@@ -97,7 +97,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const inputRef = ${{ inputs.OPENVM_REV }} || "${{ github.event.inputs.OPENVM_REV }}";
+            const inputRef = "${{ inputs.OPENVM_REV || github.event.inputs.OPENVM_REV }}";
             if (inputRef && inputRef.trim()) {
               return inputRef;
             } else {

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -152,14 +152,18 @@ jobs:
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
-
+      - name: Set tag
+        id: set-tag
+        run: |
+          CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -f1)
+          echo "tag=$(git rev-parse HEAD)-${CARGO_LOCK_HASH}" >> $GITHUB_OUTPUT
       - name: Create or update branch
         id: create-branch
         run: |
           if [ "${{ github.event_name == 'schedule' }}" = "true" ]; then
             BRANCH_NAME="nightly"
           else
-            BRANCH_NAME="patch-openvm-$(date +%Y%m%d%H%M%S)-${{ github.run_id }}-${{ github.run_attempt }}"
+            BRANCH_NAME="patch-openvm-$(date +%Y%m%d%H%M%S)-${{ steps.set-tag.outputs.tag }}"
           fi
           # Delete local branch if it exists
           git branch -D "$BRANCH_NAME" 2>/dev/null || true
@@ -173,11 +177,6 @@ jobs:
           git push -f origin "$BRANCH_NAME"
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "${{ github.event_name }}"
-      - name: Set tag
-        id: set-tag
-        run: |
-          CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -f1)
-          echo "tag=$(git rev-parse HEAD)-${CARGO_LOCK_HASH}" >> $GITHUB_OUTPUT
       - name: Create pull request
         if: ${{ !inputs.manual_call }}
         uses: repo-sync/pull-request@v2

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -174,6 +174,7 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "${{ github.event_name }}"
       - name: Set tag
+        id: set-tag
         run: |
           CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -f1)
           echo "tag=$(git rev-parse HEAD)-${CARGO_LOCK_HASH}" >> $GITHUB_OUTPUT

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -155,7 +155,7 @@ jobs:
       - name: Set tag
         id: set-tag
         run: |
-          CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -f1)
+          CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -d' ' -f1 | cut -c1-8)
           echo "tag=$(git rev-parse HEAD)-${CARGO_LOCK_HASH}" >> $GITHUB_OUTPUT
       - name: Create or update branch
         id: create-branch

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -59,9 +59,9 @@ on:
       BENCHER_API_TOKEN:
         required: true
     outputs:
-      metric_path:
-        description: "Path to the metric json file"
-        value: ${{ jobs.run-benchmark.outputs.metric_path }}
+      metric_name:
+        description: "Name of the metric"
+        value: ${{ jobs.run-benchmark.outputs.metric_name }}
 
 jobs:
   update-config:

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -167,7 +167,7 @@ jobs:
           echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - name: Create pull request
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.event.inputs != null }}
         uses: repo-sync/pull-request@v2
         id: create-pr
         with:
@@ -195,7 +195,7 @@ jobs:
 
   close-pr:
     needs: [update-config, run-benchmark]
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event.inputs != null }}
     runs-on: ubuntu-latest
     steps:
       - name: Close PR

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -80,10 +80,10 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            if ("${{ inputs.STARK_BACKEND_REV || github.event.inputs.STARK_BACKEND_REV }}" !== "") {
-              return "${{ inputs.STARK_BACKEND_REV || github.event.inputs.STARK_BACKEND_REV }}";
+            const inputRef = inputs.STARK_BACKEND_REV || github.event.inputs.STARK_BACKEND_REV;
+            if (inputRef && inputRef.trim()) {
+              return inputRef;
             } else {
-              // Otherwise fetch latest commit of main
               const { data } = await github.rest.repos.getCommit({
                 owner: 'openvm-org',
                 repo: 'stark-backend',
@@ -97,8 +97,9 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            if ("${{ inputs.OPENVM_REV || github.event.inputs.OPENVM_REV }}" !== "") {
-              return "${{ inputs.OPENVM_REV || github.event.inputs.OPENVM_REV }}";
+            const inputRef = inputs.OPENVM_REV || github.event.inputs.OPENVM_REV;
+            if (inputRef && inputRef.trim()) {
+              return inputRef;
             } else {
               // Otherwise fetch latest commit of main
               const { data } = await github.rest.repos.getCommit({

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -80,9 +80,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            if ("${{ github.event.inputs.STARK_BACKEND_REV }}" !== "") {
-              // If provided by user, simply return it
-              return "${{ github.event.inputs.STARK_BACKEND_REV }}";
+            if ("${{ inputs.STARK_BACKEND_REV || github.event.inputs.STARK_BACKEND_REV }}" !== "") {
+              return "${{ inputs.STARK_BACKEND_REV || github.event.inputs.STARK_BACKEND_REV }}";
             } else {
               // Otherwise fetch latest commit of main
               const { data } = await github.rest.repos.getCommit({
@@ -98,9 +97,8 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            if ("${{ github.event.inputs.OPENVM_REV }}" !== "") {
-              // If provided by user, simply return it
-              return "${{ github.event.inputs.OPENVM_REV }}";
+            if ("${{ inputs.OPENVM_REV || github.event.inputs.OPENVM_REV }}" !== "") {
+              return "${{ inputs.OPENVM_REV || github.event.inputs.OPENVM_REV }}";
             } else {
               // Otherwise fetch latest commit of main
               const { data } = await github.rest.repos.getCommit({
@@ -183,7 +181,7 @@ jobs:
 
   run-benchmark:
     needs: update-config
-    if: ${{ github.event.inputs.run_benchmark == 'true' || github.event_name == 'schedule' || inputs.run_benchmark == 'true' }}
+    if: ${{ github.event.inputs.run_benchmark == 'true' || github.event_name == 'schedule' || inputs.run_benchmark }}
     uses: ./.github/workflows/reth-benchmark.yml
     with:
       mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode }}

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const inputRef = context.inputs?.STARK_BACKEND_REV || github.event.inputs?.STARK_BACKEND_REV;
+            const inputRef = ${{ inputs.STARK_BACKEND_REV }} || "${{ github.event.inputs.STARK_BACKEND_REV }}";
             if (inputRef && inputRef.trim()) {
               return inputRef;
             } else {
@@ -97,7 +97,7 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
-            const inputRef = context.inputs?.OPENVM_REV || github.event.inputs?.OPENVM_REV;
+            const inputRef = ${{ inputs.OPENVM_REV }} || "${{ github.event.inputs.OPENVM_REV }}";
             if (inputRef && inputRef.trim()) {
               return inputRef;
             } else {


### PR DESCRIPTION
Adds runs-on cache of:
- elf
- host binary

Because we create a new branch for patching, the cache key isn't the git commit, but the commit_before_patch-sha256sum(Cargo.lock). Over hash with the full github input, even though most parameters don't affect the build.