### PR TITLE
fix: do not upload flamegraph summary metrics to bencher

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -368,7 +368,7 @@ jobs:
 
       - uses: bencherdev/bencher@main
       - name: Upload bencher metrics
-        if: ${{ inputs.profiling || github.event.inputs.profiling || 'none' }} == 'none'
+        if: ${{ inputs.profiling == 'none' || github.event.inputs.profiling == 'none' }}
         run: |
           current_branch=$(git rev-parse --abbrev-ref HEAD)
           if [[ "$current_branch" == nightly* ]]; then


### PR DESCRIPTION
Runtimes from both host and guest flamegraphs are currently being uploaded to bencher, which clutters the graphs.