### PR TITLE
Update openvm-benchmarks to openvm-benchmarks-prove

### DIFF
--- a/.cargo/config.template.toml
+++ b/.cargo/config.template.toml
@@ -6,7 +6,7 @@ openvm-stark-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.gi
 openvm-stark-sdk = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
 
 [patch."https://github.com/openvm-org/openvm.git"]
-openvm-benchmarks = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-benchmarks-prove = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-sdk = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 cargo-openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-mod-circuit-builder = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }


### PR DESCRIPTION
After the `openvm-benchmarks` crate was changed in [this PR](https://github.com/openvm-org/openvm/pull/1556), the "Update openvm patches" workflow [fails](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/14339818453/job/40196051565) since it the `openvm-benchmarks` crate no longer exists.

This PR updates the dependency to `openvm-benchmarks-prove` which is the newly renamed benchmarks crate.