### PR TITLE
fix: Guest flamegraph

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -249,7 +249,7 @@ jobs:
           cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
       - name: Checkout openvm (for scripts)
         run: |
-          git clone --depth=1 https://github.com/openvm-org/openvm.git
+          git clone --depth=1 -b fix/fn_bounds https://github.com/openvm-org/openvm.git
 
       - name: Install architecture specific tools
         run: |

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -400,7 +400,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Benchmark Metrics
-        run: s5cmd cp -r ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}
+        run: s5cmd cp ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}
 
       - name: Generate markdown
         run: |

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -400,7 +400,7 @@ jobs:
           retention-days: 1
 
       - name: Upload Benchmark Metrics
-        run: s5cmd cp ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}
+        run: s5cmd cp ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}
 
       - name: Generate markdown
         run: |

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -167,6 +167,7 @@ on:
 env:
   S3_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/results
   S3_METRICS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/metrics
+  S3_METRICS_SYMBOLS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/metrics-symbols
   S3_FLAMEGRAPHS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/flamegraphs
   S3_FLAMEGRAPHS_URL: https://axiom-public-data-sandbox-us-east-1.s3.us-east-1.amazonaws.com/benchmark/github/flamegraphs
   S3_SAMPLY_PROFILE_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/samply
@@ -214,7 +215,9 @@ jobs:
           METRIC_NAME=reth-$current_sha-${input_hash}
           echo "METRIC_NAME=${METRIC_NAME}" >> $GITHUB_ENV
           METRIC_PATH=".bench_metrics/${METRIC_NAME}.json"
+          METRIC_SYMBOLS_PATH=".bench_metrics/${METRIC_NAME}.syms"
           echo "METRIC_PATH=${METRIC_PATH}" >> $GITHUB_ENV
+          echo "METRIC_SYMBOLS_PATH=${METRIC_SYMBOLS_PATH}" >> $GITHUB_ENV
           echo "name=${METRIC_NAME}" >> $GITHUB_OUTPUT
       - name: Set cache keys
         id: set-cache-keys
@@ -370,6 +373,7 @@ jobs:
           export JEMALLOC_SYS_WITH_MALLOC_CONF=${JEMALLOC_SYS_WITH_MALLOC_CONF}
           export RUST_LOG="info,p3_=warn"
           export OUTPUT_PATH=${METRIC_PATH}
+          export SYMS_PATH=${METRIC_SYMBOLS_PATH}
 
           if [[ "${{ inputs.profiling || github.event.inputs.profiling }}" == "host" ]]; then
             echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
@@ -388,6 +392,13 @@ jobs:
         with:
           name: ${{ steps.set-metric-name.outputs.name }}
           path: ${{ env.METRIC_PATH }}
+          retention-days: 1
+      - name: Upload metric symbols
+        id: upload-metric-symbols
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-metric-name.outputs.name }}-symbols
+          path: ${{ env.METRIC_SYMBOLS_PATH }}
           retention-days: 1
       - name: Upload memory usage graph
         if: ${{ (inputs.profiling || github.event.inputs.profiling) == 'none' }}
@@ -433,7 +444,7 @@ jobs:
         run: |
           cargo install inferno
 
-          python3 openvm/ci/scripts/metric_unify/flamegraph.py $METRIC_PATH
+          python3 openvm/ci/scripts/metric_unify/flamegraph.py $METRIC_PATH --metrics_syms $METRIC_SYMBOLS_PATH
           s5cmd cp '.bench_metrics/flamegraphs/*.svg' "${{ env.S3_FLAMEGRAPHS_PATH }}/${METRIC_NAME}/"
 
           echo "" >> $MD_PATH

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -246,7 +246,7 @@ jobs:
 
       - name: Install openvm-prof
         run: |
-          cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
+          cargo install --git https://github.com/openvm-org/openvm.git --branch fix/fn_bounds --profile=dev --force openvm-prof
       - name: Checkout openvm (for scripts)
         run: |
           git clone --depth=1 -b fix/fn_bounds https://github.com/openvm-org/openvm.git

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -167,7 +167,6 @@ on:
 env:
   S3_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/results
   S3_METRICS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/metrics
-  S3_METRICS_SYMBOLS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/metrics-symbols
   S3_FLAMEGRAPHS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/flamegraphs
   S3_FLAMEGRAPHS_URL: https://axiom-public-data-sandbox-us-east-1.s3.us-east-1.amazonaws.com/benchmark/github/flamegraphs
   S3_SAMPLY_PROFILE_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/samply
@@ -214,10 +213,9 @@ jobs:
           input_hash=$(echo $input_json_str | sha256sum | cut -d' ' -f1)
           METRIC_NAME=reth-$current_sha-${input_hash}
           echo "METRIC_NAME=${METRIC_NAME}" >> $GITHUB_ENV
-          METRIC_PATH=".bench_metrics/${METRIC_NAME}.json"
-          METRIC_SYMBOLS_PATH=".bench_metrics/${METRIC_NAME}.syms"
+          mkdir -p .bench_metrics/${METRIC_NAME}
+          METRIC_PATH=".bench_metrics/${METRIC_NAME}"
           echo "METRIC_PATH=${METRIC_PATH}" >> $GITHUB_ENV
-          echo "METRIC_SYMBOLS_PATH=${METRIC_SYMBOLS_PATH}" >> $GITHUB_ENV
           echo "name=${METRIC_NAME}" >> $GITHUB_OUTPUT
       - name: Set cache keys
         id: set-cache-keys
@@ -372,8 +370,8 @@ jobs:
         run: |
           export JEMALLOC_SYS_WITH_MALLOC_CONF=${JEMALLOC_SYS_WITH_MALLOC_CONF}
           export RUST_LOG="info,p3_=warn"
-          export OUTPUT_PATH=${METRIC_PATH}
-          export SYMS_PATH=${METRIC_SYMBOLS_PATH}
+          export OUTPUT_PATH=${METRIC_PATH}/metrics.json
+          export GUEST_SYMBOLS_PATH=${METRIC_PATH}/guest.syms
 
           if [[ "${{ inputs.profiling || github.event.inputs.profiling }}" == "host" ]]; then
             echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
@@ -386,19 +384,12 @@ jobs:
             echo "MEM_USAGE_PATH=memory_usage.png" >> $GITHUB_ENV
           fi
 
-      - name: Upload metric file
-        id: upload-metric-artifact
+      - name: Upload metric artifacts
+        id: upload-metric-artifacts
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-metric-name.outputs.name }}
           path: ${{ env.METRIC_PATH }}
-          retention-days: 1
-      - name: Upload metric symbols
-        id: upload-metric-symbols
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.set-metric-name.outputs.name }}-symbols
-          path: ${{ env.METRIC_SYMBOLS_PATH }}
           retention-days: 1
       - name: Upload memory usage graph
         if: ${{ (inputs.profiling || github.event.inputs.profiling) == 'none' }}
@@ -409,13 +400,13 @@ jobs:
           retention-days: 1
 
       - name: Upload Benchmark Metrics
-        run: s5cmd cp ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}.json
+        run: s5cmd cp -r ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}
 
       - name: Generate markdown
         run: |
           BENCHER_METRIC_PATH=bencher.json
-          openvm-prof --json-paths $METRIC_PATH --output-json $BENCHER_METRIC_PATH
-          MD_PATH=${METRIC_PATH%.json}.md
+          openvm-prof --json-paths $METRIC_PATH/metrics.json --output-json $BENCHER_METRIC_PATH
+          MD_PATH=${METRIC_PATH}.md
           echo "MD_PATH=${MD_PATH}" >> $GITHUB_ENV
           echo "BENCHER_METRIC_PATH=${BENCHER_METRIC_PATH}" >> $GITHUB_ENV
 
@@ -444,7 +435,7 @@ jobs:
         run: |
           cargo install inferno
 
-          python3 openvm/ci/scripts/metric_unify/flamegraph.py $METRIC_PATH --metrics_syms $METRIC_SYMBOLS_PATH
+          python3 openvm/ci/scripts/metric_unify/flamegraph.py $METRIC_PATH/metrics.json --guest-symbols $METRIC_PATH/guest.syms
           s5cmd cp '.bench_metrics/flamegraphs/*.svg' "${{ env.S3_FLAMEGRAPHS_PATH }}/${METRIC_NAME}/"
 
           echo "" >> $MD_PATH

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -244,10 +244,10 @@ jobs:
 
       - name: Install openvm-prof
         run: |
-          cargo install --git https://github.com/openvm-org/openvm.git --branch fix/fn_bounds --profile=dev --force openvm-prof
+          cargo install --git https://github.com/openvm-org/openvm.git --profile=dev --force openvm-prof
       - name: Checkout openvm (for scripts)
         run: |
-          git clone --depth=1 -b fix/fn_bounds https://github.com/openvm-org/openvm.git
+          git clone --depth=1 https://github.com/openvm-org/openvm.git
 
       - name: Install architecture specific tools
         run: |

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -400,7 +400,9 @@ jobs:
           retention-days: 1
 
       - name: Upload Benchmark Metrics
-        run: s5cmd cp ${METRIC_PATH} ${{ env.S3_METRICS_PATH }}
+        run: |
+          s5cmd cp $METRIC_PATH/metrics.json ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/metrics.json
+          s5cmd cp $METRIC_PATH/guest.syms ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/guest.syms
 
       - name: Generate markdown
         run: |

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -371,7 +371,9 @@ jobs:
           export JEMALLOC_SYS_WITH_MALLOC_CONF=${JEMALLOC_SYS_WITH_MALLOC_CONF}
           export RUST_LOG="info,p3_=warn"
           export OUTPUT_PATH=${METRIC_PATH}/metrics.json
-          export GUEST_SYMBOLS_PATH=${METRIC_PATH}/guest.syms
+          if [[ "${{ inputs.profiling || github.event.inputs.profiling }}" == "guest" ]]; then
+            export GUEST_SYMBOLS_PATH=${METRIC_PATH}/guest.syms
+          fi
 
           if [[ "${{ inputs.profiling || github.event.inputs.profiling }}" == "host" ]]; then
             echo -1 | sudo tee /proc/sys/kernel/perf_event_paranoid
@@ -402,7 +404,9 @@ jobs:
       - name: Upload Benchmark Metrics
         run: |
           s5cmd cp ${METRIC_PATH}/metrics.json ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/metrics.json
-          s5cmd cp ${METRIC_PATH}/guest.syms ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/guest.syms
+          if [[ "${{ inputs.profiling || github.event.inputs.profiling }}" == "guest" ]]; then
+            s5cmd cp ${METRIC_PATH}/guest.syms ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/guest.syms
+          fi
 
       - name: Generate markdown
         run: |

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -401,14 +401,14 @@ jobs:
 
       - name: Upload Benchmark Metrics
         run: |
-          s5cmd cp $METRIC_PATH/metrics.json ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/metrics.json
-          s5cmd cp $METRIC_PATH/guest.syms ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/guest.syms
+          s5cmd cp ${METRIC_PATH}/metrics.json ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/metrics.json
+          s5cmd cp ${METRIC_PATH}/guest.syms ${{ env.S3_METRICS_PATH }}/${METRIC_NAME}/guest.syms
 
       - name: Generate markdown
         run: |
           BENCHER_METRIC_PATH=bencher.json
-          openvm-prof --json-paths $METRIC_PATH/metrics.json --output-json $BENCHER_METRIC_PATH
-          MD_PATH=${METRIC_PATH}.md
+          openvm-prof --json-paths ${METRIC_PATH}/metrics.json --output-json $BENCHER_METRIC_PATH
+          MD_PATH=${METRIC_PATH}/metrics.md
           echo "MD_PATH=${MD_PATH}" >> $GITHUB_ENV
           echo "BENCHER_METRIC_PATH=${BENCHER_METRIC_PATH}" >> $GITHUB_ENV
 
@@ -437,7 +437,7 @@ jobs:
         run: |
           cargo install inferno
 
-          python3 openvm/ci/scripts/metric_unify/flamegraph.py $METRIC_PATH/metrics.json --guest-symbols $METRIC_PATH/guest.syms
+          python3 openvm/ci/scripts/metric_unify/flamegraph.py ${METRIC_PATH}/metrics.json --guest-symbols ${METRIC_PATH}/guest.syms
           s5cmd cp '.bench_metrics/flamegraphs/*.svg' "${{ env.S3_FLAMEGRAPHS_PATH }}/${METRIC_NAME}/"
 
           echo "" >> $MD_PATH

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3233,9 +3233,9 @@ checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "syn 2.0.100",
 ]
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4607,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
 dependencies = [
  "elf",
  "eyre",
@@ -5653,9 +5653,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,16 @@
 version = 4
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
+
+[[package]]
 name = "addchain"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +37,17 @@ name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
 
 [[package]]
 name = "ahash"
@@ -61,7 +82,7 @@ version = "0.1.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28e2652684758b0d9b389d248b209ed9fd9989ef489a550265fe4bb8454fe7eb"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "num_enum",
  "serde",
@@ -75,7 +96,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "629b62e38d471cc15fea534eb7283d2f8a4e8bdb1811bcc5d66dda6cfce6fae1"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -88,7 +109,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "serde",
 ]
@@ -99,7 +120,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "k256",
  "serde",
@@ -111,7 +132,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c986539255fb839d1533c128e190e557e52ff652c9ef62939e233a81dd93f7e"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "derive_more 1.0.0",
  "k256",
@@ -126,7 +147,7 @@ checksum = "f923dd5fca5f67a43d81ed3ebad0880bd41f6dd0ada930030353ac356c54cd0f"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702 0.1.1",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
@@ -142,7 +163,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a7a18afb0b318616b6b2b0e2e7ac5529d32a966c673b48091c9919e284e6aca"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-serde",
  "serde",
 ]
@@ -153,7 +174,7 @@ version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -165,7 +186,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3c717b5298fad078cd3a418335b266eba91b511383ca9bd497f742d5975d5ab"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-sol-types",
  "serde",
  "serde_json",
@@ -183,7 +204,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "alloy-signer",
@@ -201,9 +222,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94ad40869867ed2d9cd3842b1e800889e5b49e6b92da346e93862b4a741bedf3"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-serde",
  "serde",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e416903084d3392ebd32d94735c395d6709415b76c7728e594d3f996f2b03e65"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 0.99.19",
+ "hex-literal",
+ "itoa",
+ "ruint",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0628ec0ba5b98b3370bb6be17b12f23bfce8ee4ad83823325a20546d9b03b78"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 0.99.19",
+ "hex-literal",
+ "itoa",
+ "ruint",
+ "tiny-keccak",
 ]
 
 [[package]]
@@ -246,7 +300,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-client",
  "alloy-rpc-types-eth",
  "alloy-transport",
@@ -259,7 +313,7 @@ dependencies = [
  "futures-utils-wasm",
  "lru",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -301,7 +355,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "tokio",
@@ -331,7 +385,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -349,7 +403,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "731f75ec5d383107fd745d781619bd9cedf145836c51ecb991623d41278e71fa"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "serde",
  "serde_json",
 ]
@@ -360,7 +414,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "307324cca94354cd654d6713629f0383ec037e1ff9e3e3d547212471209860c0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "async-trait",
  "auto_impl",
  "elliptic-curve",
@@ -426,7 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -436,7 +490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -469,7 +523,7 @@ checksum = "a944f5310c690b62bbb3e7e5ce34527cbd36b2d18532a797af123271ce595a49"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "reqwest 0.12.15",
  "serde_json",
  "tower",
  "tracing",
@@ -482,7 +536,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a46c9c4fdccda7982e7928904bd85fe235a0404ee3d7e197fff13d61eac8b4f"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "derive_more 1.0.0",
  "hashbrown 0.14.5",
@@ -571,6 +625,16 @@ name = "anyhow"
 version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
+name = "ariadne"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "367fd0ad87307588d087544707bc5fbf4805ded96c7db922b70d368fa1cb5702"
+dependencies = [
+ "unicode-width",
+ "yansi 0.5.1",
+]
 
 [[package]]
 name = "ark-ff"
@@ -709,6 +773,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +812,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -838,12 +920,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -874,6 +971,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -914,7 +1017,7 @@ checksum = "06e903a20b159e944f91ec8499fe1e55651480c541ea0a584f5d967c49ad9d99"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -927,7 +1030,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -990,6 +1093,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "build_const"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ae4235e6dac0694637c763029ecea1a2ec9e4e06ec2729bd21ba4d9c863eb7"
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,6 +1139,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1075,6 +1214,8 @@ version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1101,6 +1242,16 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1190,6 +1341,12 @@ dependencies = [
 
 [[package]]
 name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
@@ -1207,6 +1364,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1238,6 +1405,15 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam"
@@ -1503,6 +1679,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1583,6 +1801,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ena"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1644,6 +1880,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethabi"
+version = "18.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7413c5f74cc903ea37386a8965a936cbeb334bd270862fdece542c1b2dcbc898"
+dependencies = [
+ "ethereum-types",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3",
+ "thiserror 1.0.69",
+ "uint",
+]
+
+[[package]]
 name = "ethbloom"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1651,6 +1904,10 @@ checksum = "c22d4b5885b6aa2fe5e8b9329fb8d232bf739e434e6b87347c63bdd00c120f60"
 dependencies = [
  "crunchy",
  "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
  "tiny-keccak",
 ]
 
@@ -1662,8 +1919,90 @@ checksum = "02d215cbf040552efcbe99a38372fe80ab9d00268e20012b79fcd0f073edd8ee"
 dependencies = [
  "ethbloom",
  "fixed-hash",
+ "impl-codec",
+ "impl-rlp",
+ "impl-serde",
  "primitive-types",
+ "scale-info",
  "uint",
+]
+
+[[package]]
+name = "ethers-core"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d80cc6ad30b14a48ab786523af33b37f28a8623fc06afd55324816ef18fb1f"
+dependencies = [
+ "arrayvec",
+ "bytes",
+ "chrono",
+ "const-hex",
+ "elliptic-curve",
+ "ethabi",
+ "generic-array",
+ "k256",
+ "num_enum",
+ "open-fastrlp",
+ "rand 0.8.5",
+ "rlp",
+ "serde",
+ "serde_json",
+ "strum 0.26.3",
+ "tempfile",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "unicode-xid",
+]
+
+[[package]]
+name = "ethers-etherscan"
+version = "2.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79e5973c26d4baf0ce55520bd732314328cabe53193286671b47144145b9649"
+dependencies = [
+ "chrono",
+ "ethers-core",
+ "reqwest 0.11.27",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "ethers-solc"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de34e484e7ae3cab99fbfd013d6c5dc7f9013676a4e0e414d8b12e1213e8b3ba"
+dependencies = [
+ "cfg-if",
+ "const-hex",
+ "dirs",
+ "dunce",
+ "ethers-core",
+ "futures-util",
+ "glob",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "sha2",
+ "solang-parser",
+ "svm-rs",
+ "svm-rs-builds",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi 0.5.1",
 ]
 
 [[package]]
@@ -1733,6 +2072,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "pear",
+ "serde",
+ "toml 0.8.20",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,6 +2095,22 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hex",
  "static_assertions",
+]
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1757,12 +2126,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "forge-fmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0b82597ff80bc12b3b001dfb968769c345e353650dd32d337f2c64d2167c88"
+dependencies = [
+ "alloy-primitives 0.3.3",
+ "ariadne",
+ "foundry-config",
+ "itertools 0.11.0",
+ "solang-parser",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foundry-config"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a64a9bdad47eb4d950523b8ff14e675db8f2226a2aef79063d9344449b3abd5"
+dependencies = [
+ "Inflector",
+ "dirs-next",
+ "ethers-core",
+ "ethers-etherscan",
+ "ethers-solc",
+ "eyre",
+ "figment",
+ "globset",
+ "number_prefix",
+ "once_cell",
+ "open-fastrlp",
+ "path-slash",
+ "regex",
+ "reqwest 0.11.27",
+ "revm-primitives 1.3.0",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "thiserror 1.0.69",
+ "toml 0.7.8",
+ "toml_edit 0.19.15",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1941,6 +2367,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
 name = "group"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1961,6 +2400,25 @@ dependencies = [
  "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.8.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -2187,6 +2645,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,12 +2677,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -2215,8 +2704,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2227,6 +2716,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,8 +2754,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2247,20 +2766,34 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 0.26.8",
 ]
 
 [[package]]
@@ -2272,9 +2805,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.6.0",
  "libc",
  "pin-project-lite",
  "socket2",
@@ -2462,6 +2995,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,6 +3049,21 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
  "serde",
+]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2553,6 +3119,16 @@ name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jobserver"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
+dependencies = [
+ "getrandom 0.3.2",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -2611,6 +3187,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "regex",
+ "regex-syntax 0.8.5",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata 0.4.9",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +3244,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b20daca3a4ac14dbdc753c5e90fc7b490a48a9131daed3c9a9ced7b2defd37b"
 dependencies = [
  "cc",
+ "libc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.9.0",
  "libc",
 ]
 
@@ -2712,6 +3328,16 @@ checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
 dependencies = [
  "cfg-if",
  "rayon",
+]
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2827,6 +3453,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nibble_vec"
@@ -2964,10 +3596,17 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nums"
@@ -3017,7 +3656,7 @@ checksum = "21aad1fbf80d2bcd7406880efc7ba109365f44bbb72896758ddcbfa46bf1592c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 1.0.0",
@@ -3033,7 +3672,7 @@ checksum = "e281fbfc2198b7c0c16457d6524f83d192662bc9f3df70f24c3038d4521616df"
 dependencies = [
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "cfg-if",
@@ -3044,9 +3683,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "open-fastrlp"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "786393f80485445794f6043fd3138854dd109cc6c4bd1a6383db304c9ce9b9ce"
+dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "bytes",
+ "ethereum-types",
+ "open-fastrlp-derive",
+]
+
+[[package]]
+name = "open-fastrlp-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "003b2be5c6c53c1cfeb0a238b8a1c3915cd410feb684457a36c10038f764bb1c"
+dependencies = [
+ "bytes",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "openvm"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -3058,8 +3722,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3087,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3096,8 +3760,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3109,8 +3773,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3119,8 +3783,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -3133,8 +3797,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-prove"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -3170,8 +3834,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-utils"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3185,8 +3849,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3207,8 +3871,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -3221,8 +3885,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3236,8 +3900,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -3248,8 +3912,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3280,8 +3944,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -3290,8 +3954,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3305,8 +3969,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -3317,7 +3981,7 @@ dependencies = [
 name = "openvm-client-executor"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "bincode 2.0.0-rc.3",
  "bincode_derive",
@@ -3352,8 +4016,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -3368,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3377,8 +4041,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3408,8 +4072,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -3433,8 +4097,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3443,8 +4107,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -3459,7 +4123,7 @@ dependencies = [
 name = "openvm-host-executor"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-provider",
  "alloy-rlp",
  "alloy-rpc-types",
@@ -3493,8 +4157,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -3510,8 +4174,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3519,8 +4183,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3545,8 +4209,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -3554,8 +4218,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3568,16 +4232,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -3597,7 +4261,7 @@ dependencies = [
 name = "openvm-mpt"
 version = "0.1.0"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-trie",
@@ -3622,8 +4286,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3649,8 +4313,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -3673,8 +4337,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3682,8 +4346,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -3710,8 +4374,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3740,8 +4404,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -3766,8 +4430,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3780,8 +4444,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
@@ -3791,8 +4455,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -3899,8 +4563,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3919,8 +4583,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3942,8 +4606,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -3951,8 +4615,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -3967,10 +4631,9 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
- "alloy-primitives",
  "alloy-sol-types",
  "async-trait",
  "bitcode",
@@ -3979,6 +4642,7 @@ dependencies = [
  "derivative",
  "derive_more 1.0.0",
  "eyre",
+ "forge-fmt",
  "getset",
  "hex",
  "itertools 0.14.0",
@@ -4020,8 +4684,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4031,8 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4054,8 +4718,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4063,8 +4727,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4131,7 +4795,7 @@ dependencies = [
  "serde",
  "serde_json",
  "static_assertions",
- "toml",
+ "toml 0.8.20",
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
@@ -4140,8 +4804,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.0.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=59391092804d54615790b90549b76a36e68a6f21#59391092804d54615790b90549b76a36e68a6f21"
+version = "1.0.1-rc.0"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
 dependencies = [
  "elf",
  "eyre",
@@ -4149,6 +4813,7 @@ dependencies = [
  "openvm-platform",
  "openvm-stark-backend",
  "rrs-lib",
+ "rustc-demangle",
  "thiserror 1.0.69",
 ]
 
@@ -4162,6 +4827,12 @@ dependencies = [
  "revm-primitives 9.0.2",
  "serde",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -4564,6 +5235,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4574,6 +5255,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4613,6 +5305,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi 1.0.1",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4627,6 +5360,58 @@ dependencies = [
  "memchr",
  "thiserror 2.0.12",
  "ucd-trie",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.8.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -4672,6 +5457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,6 +5499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
 name = "prettyplease"
 version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4734,6 +5531,9 @@ checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
+ "impl-serde",
+ "scale-info",
  "uint",
 ]
 
@@ -4743,7 +5543,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -4778,14 +5578,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "version_check",
+ "yansi 1.0.1",
+]
+
+[[package]]
 name = "proptest"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags",
+ "bit-set 0.8.0",
+ "bit-vec 0.8.0",
+ "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
  "rand 0.8.5",
@@ -4830,7 +5643,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.25",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -4849,7 +5662,7 @@ dependencies = [
  "rand 0.9.0",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -4979,7 +5792,7 @@ version = "11.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6df7ab838ed27997ba19a4664507e6f82b41fe6e20be42929332156e5e85146"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -5008,7 +5821,18 @@ version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.15",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5057,6 +5881,47 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 0.25.4",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
@@ -5065,11 +5930,11 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5079,22 +5944,22 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
- "rustls-pemfile",
+ "rustls 0.23.25",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.2",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.26.8",
  "windows-registry",
 ]
 
@@ -5118,7 +5983,7 @@ dependencies = [
  "alloy-chains",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-trie",
  "auto_impl",
  "derive_more 1.0.0",
@@ -5140,7 +6005,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
@@ -5222,7 +6087,7 @@ version = "1.0.6"
 source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a5ec87b8ce2d2793b12192a335255674164"
 dependencies = [
  "alloy-chains",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "auto_impl",
  "crc",
@@ -5295,7 +6160,7 @@ version = "1.0.6"
 source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a5ec87b8ce2d2793b12192a335255674164"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "derive_more 1.0.0",
  "nybbles",
@@ -5332,7 +6197,7 @@ name = "reth-network-peers"
 version = "1.0.6"
 source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a5ec87b8ce2d2793b12192a335255674164"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "enr",
  "serde_with",
@@ -5346,7 +6211,7 @@ version = "1.0.6"
 source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a5ec87b8ce2d2793b12192a335255674164"
 dependencies = [
  "alloy-chains",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "derive_more 1.0.0",
  "once_cell",
  "reth-chainspec",
@@ -5375,7 +6240,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types",
  "alloy-serde",
@@ -5406,7 +6271,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "byteorder",
@@ -5424,7 +6289,7 @@ name = "reth-prune-types"
 version = "1.0.6"
 source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a5ec87b8ce2d2793b12192a335255674164"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
@@ -5453,7 +6318,7 @@ name = "reth-stages-types"
 version = "1.0.6"
 source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a5ec87b8ce2d2793b12192a335255674164"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "bytes",
  "modular-bitfield",
  "reth-codecs",
@@ -5466,7 +6331,7 @@ name = "reth-static-file-types"
 version = "1.0.6"
 source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a5ec87b8ce2d2793b12192a335255674164"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "derive_more 1.0.0",
  "serde",
  "strum 0.26.3",
@@ -5525,7 +6390,7 @@ source = "git+https://github.com/axiom-crypto/reth?branch=openvm%2Fv1.0.6#06be1a
 dependencies = [
  "alloy-consensus",
  "alloy-genesis",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-trie",
  "bytes",
@@ -5628,14 +6493,30 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51187b852d9e458816a2e19c81f1dd6c924077e1a8fccd16e4f044f865f299d7"
+dependencies = [
+ "alloy-primitives 0.4.2",
+ "alloy-rlp",
+ "auto_impl",
+ "bitflags 2.9.0",
+ "bitvec",
+ "enumn",
+ "hashbrown 0.14.5",
+ "hex",
+]
+
+[[package]]
+name = "revm-primitives"
 version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7a6bff9dbde3370a5ac9555104117f7e6039b3cc76e8d5d9d01899088beca2a"
 dependencies = [
  "alloy-eips",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "auto_impl",
- "bitflags",
+ "bitflags 2.9.0",
  "bitvec",
  "c-kzg",
  "cfg-if",
@@ -5654,9 +6535,9 @@ checksum = "3702f132bb484f4f0d0ca4f6fbde3c82cfd745041abbedd6eda67730e1868ef0"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702 0.4.2",
- "alloy-primitives",
+ "alloy-primitives 0.8.25",
  "auto_impl",
- "bitflags",
+ "bitflags 2.9.0",
  "bitvec",
  "c-kzg",
  "cfg-if",
@@ -5706,7 +6587,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
+ "rlp-derive",
  "rustc-hex",
+]
+
+[[package]]
+name = "rlp-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33d7b2abe0c340d8797fe2907d3f20d3b5ea5908683618bfe80df7f621f672a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -5810,11 +6703,23 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -5826,9 +6731,18 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -5847,6 +6761,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 dependencies = [
  "web-time",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -5885,10 +6809,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "scale-info"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346a3b32eba2640d17a9cb5927056b08f3de90f65b72fe09402c2ad07d684d0b"
+dependencies = [
+ "cfg-if",
+ "derive_more 1.0.0",
+ "parity-scale-codec",
+ "scale-info-derive",
+]
+
+[[package]]
+name = "scale-info-derive"
+version = "2.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6630024bf739e2179b91fb424b28898baf819414262c5d376677dbff1fe7ebf"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -6002,6 +6969,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6053,6 +7030,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6099,6 +7087,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6107,6 +7104,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -6188,6 +7191,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "solang-parser"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb9fa2fa2fa6837be8a2495486ff92e3ffe68a99b6eeba288e139efdd842457"
+dependencies = [
+ "itertools 0.11.0",
+ "lalrpop",
+ "lalrpop-util",
+ "phf",
+ "thiserror 1.0.69",
+ "unicode-xid",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6223,6 +7240,18 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -6294,6 +7323,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "svm-rs"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11297baafe5fa0c99d5722458eac6a5e25c01eb1b8e5cd137f54079093daa7a4"
+dependencies = [
+ "dirs",
+ "fs2",
+ "hex",
+ "once_cell",
+ "reqwest 0.11.27",
+ "semver 1.0.26",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+ "zip",
+]
+
+[[package]]
+name = "svm-rs-builds"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa64b5e8eecd3a8af7cfc311e29db31a268a62d5953233d3e8243ec77a71c4e3"
+dependencies = [
+ "build_const",
+ "hex",
+ "semver 1.0.26",
+ "serde_json",
+ "svm-rs",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6329,6 +7391,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -6348,6 +7416,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6364,6 +7453,17 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
 ]
 
 [[package]]
@@ -6574,6 +7674,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -6592,11 +7693,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls",
+ "rustls 0.23.25",
  "tokio",
 ]
 
@@ -6627,6 +7738,19 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
+dependencies = [
+ "indexmap 2.8.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.19.15",
+]
+
+[[package]]
+name = "toml"
 version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
@@ -6634,7 +7758,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.22.24",
 ]
 
 [[package]]
@@ -6648,6 +7772,19 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.8.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.5.40",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
@@ -6656,7 +7793,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -6668,7 +7805,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -6807,6 +7944,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6817,6 +7963,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-xid"
@@ -6894,6 +8046,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -7013,6 +8175,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
@@ -7035,6 +8203,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -7123,6 +8300,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7137,6 +8323,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7173,6 +8374,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7185,6 +8392,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7194,6 +8407,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7221,6 +8440,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7230,6 +8455,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7245,6 +8476,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7254,6 +8491,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7269,6 +8512,15 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
@@ -7277,12 +8529,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -7305,6 +8567,18 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
@@ -7434,6 +8708,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq 0.1.5",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
 name = "zkhash"
 version = "0.2.0"
 source = "git+https://github.com/HorizenLabs/poseidon2.git?rev=bb476b9#bb476b9ca38198cf5092487283c8b8c5d4317c4e"
@@ -7457,4 +8751,33 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
  "foldhash",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -446,7 +446,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -480,7 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.4",
+ "winnow 0.7.6",
 ]
 
 [[package]]
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "ariadne"
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1022,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.5.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65268237be94042665b92034f979c42d431d2fd998b49809543afe3e66abad1c"
+checksum = "ced38439e7a86a4761f7f7d5ded5ff009135939ecb464a24452eaa4c1696af7d"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.5.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "803c95b2ecf650eb10b5f87dda6b9f6a1b758cee53245e2b7b825c9b3803a443"
+checksum = "0ce61d2d3844c6b8d31b2353d9f66cf5e632b3e9549583fe3cac2f4f6136725e"
 dependencies = [
  "darling",
  "ident_case",
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
 dependencies = [
  "jobserver",
  "libc",
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.35"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1871,9 +1871,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2356,9 +2356,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glam"
-version = "0.30.1"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3aa70d918d2b234126ff4f850f628f172542bf0603ded26b8ee36e5e22d5f9"
+checksum = "d0e9b6647e9b41d3a5ef02964c6be01311a7f2472fea40595c635c6d046c259e"
 
 [[package]]
 name = "glob"
@@ -2414,7 +2414,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2788,7 +2788,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.25",
+ "rustls 0.23.26",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -3227,9 +3227,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
@@ -3239,9 +3239,9 @@ checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.41"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b20daca3a4ac14dbdc753c5e90fc7b490a48a9131daed3c9a9ced7b2defd37b"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
 dependencies = [
  "cc",
  "libc",
@@ -3259,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -3354,9 +3354,9 @@ checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "metrics"
-version = "0.23.0"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -3368,7 +3368,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62a6a1f7141f1d9bc7a886b87536bbfc97752e08b369e1e0453a9acfab5f5da4"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -3389,7 +3389,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -3400,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cb1f88093fe50061ca1195d336ffec131347c7b833db31f9ab62a2d1b7925f"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3415,9 +3415,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "syn 2.0.100",
 ]
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4607,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#d16b7633caf259895210b20ed07011b2b52965cd"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
 dependencies = [
  "elf",
  "eyre",
@@ -5369,7 +5369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
@@ -5506,9 +5506,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -5570,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -5643,7 +5643,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.25",
+ "rustls 0.23.26",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -5659,10 +5659,10 @@ checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.25",
+ "rustls 0.23.26",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -5730,13 +5730,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5817,9 +5816,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -5944,7 +5943,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.25",
+ "rustls 0.23.26",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -6604,9 +6603,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.10"
+version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652edd001c53df0b3f96a36a8dc93fce6866988efc16808235653c6bcac8bf2"
+checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6724,9 +6723,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "once_cell",
  "ring",
@@ -6961,7 +6960,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "itoa",
  "memchr",
  "ryu",
@@ -7009,7 +7008,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7088,9 +7087,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -7128,9 +7127,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
 ]
@@ -7665,9 +7664,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7707,7 +7706,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.25",
+ "rustls 0.23.26",
  "tokio",
 ]
 
@@ -7742,7 +7741,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7776,7 +7775,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7789,11 +7788,11 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.4",
+ "winnow 0.7.6",
 ]
 
 [[package]]
@@ -8210,7 +8209,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8521,9 +8520,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "syn 2.0.100",
 ]
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4607,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#e9cc404c52c355d54c5ddda150f8649dbe83e7db"
+source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#7a158d594ac09f9ef093008064667968dd11cfee"
 dependencies = [
  "elf",
  "eyre",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,7 +274,7 @@ dependencies = [
  "foldhash",
  "getrandom 0.2.15",
  "hashbrown 0.15.2",
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -446,7 +446,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck",
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -480,7 +480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.6",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -622,9 +622,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.98"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
 name = "ariadne"
@@ -835,9 +835,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.3.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
+checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1022,9 +1022,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.2"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
+checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.6.3"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ced38439e7a86a4761f7f7d5ded5ff009135939ecb464a24452eaa4c1696af7d"
+checksum = "65268237be94042665b92034f979c42d431d2fd998b49809543afe3e66abad1c"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.6.3"
+version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ce61d2d3844c6b8d31b2353d9f66cf5e632b3e9549583fe3cac2f4f6136725e"
+checksum = "803c95b2ecf650eb10b5f87dda6b9f6a1b758cee53245e2b7b825c9b3803a443"
 dependencies = [
  "darling",
  "ident_case",
@@ -1210,9 +1210,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
 dependencies = [
  "jobserver",
  "libc",
@@ -1256,9 +1256,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.37"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
+checksum = "d8aa86934b44c19c50f87cc2790e19f54f7a67aedb64101c2e1a2e5ecfb73944"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1266,9 +1266,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.37"
+version = "4.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
+checksum = "2414dbb2dd0695280da6ea9261e327479e9d37b0630f6b53ba2a11c60c679fd9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1430,9 +1430,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1550,9 +1550,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.10"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1560,9 +1560,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1871,9 +1871,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -2356,9 +2356,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glam"
-version = "0.30.2"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e9b6647e9b41d3a5ef02964c6be01311a7f2472fea40595c635c6d046c259e"
+checksum = "bf3aa70d918d2b234126ff4f850f628f172542bf0603ded26b8ee36e5e22d5f9"
 
 [[package]]
 name = "glob"
@@ -2414,7 +2414,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2788,7 +2788,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.26",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -3042,9 +3042,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
@@ -3227,21 +3227,21 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "libm"
-version = "0.2.13"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.42"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
+checksum = "6b20daca3a4ac14dbdc753c5e90fc7b490a48a9131daed3c9a9ced7b2defd37b"
 dependencies = [
  "cc",
  "libc",
@@ -3259,9 +3259,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
 
 [[package]]
 name = "litemap"
@@ -3354,9 +3354,9 @@ checksum = "3d97bbf43eb4f088f8ca469930cde17fa036207c9a5e02ccc5107c4e8b17c964"
 
 [[package]]
 name = "metrics"
-version = "0.23.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3045b4193fbdc5b5681f32f11070da9be3609f189a79f3390706d42587f46bb5"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
 dependencies = [
  "ahash",
  "portable-atomic",
@@ -3368,7 +3368,7 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62a6a1f7141f1d9bc7a886b87536bbfc97752e08b369e1e0453a9acfab5f5da4"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "itoa",
  "lockfree-object-pool",
  "metrics",
@@ -3389,7 +3389,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "hashbrown 0.14.5",
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "metrics",
  "num_cpus",
  "ordered-float",
@@ -3400,9 +3400,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.46"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
+checksum = "03cb1f88093fe50061ca1195d336ffec131347c7b833db31f9ab62a2d1b7925f"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -3415,9 +3415,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.8"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
 dependencies = [
  "adler2",
 ]
@@ -3710,7 +3710,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -3723,7 +3723,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3751,7 +3751,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3761,7 +3761,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3774,7 +3774,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3784,7 +3784,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -3798,7 +3798,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -3835,7 +3835,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3850,7 +3850,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3872,7 +3872,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -3886,7 +3886,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3901,7 +3901,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -3913,7 +3913,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3945,7 +3945,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -3955,7 +3955,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4017,7 +4017,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4032,7 +4032,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4042,7 +4042,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4073,7 +4073,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4098,7 +4098,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4108,7 +4108,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4158,7 +4158,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4175,7 +4175,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4184,7 +4184,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4210,7 +4210,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4219,7 +4219,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4233,7 +4233,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "syn 2.0.100",
 ]
@@ -4241,7 +4241,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4287,7 +4287,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4314,7 +4314,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4338,7 +4338,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4347,7 +4347,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4375,7 +4375,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4405,7 +4405,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4431,7 +4431,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4445,7 +4445,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
@@ -4456,7 +4456,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4564,7 +4564,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4584,7 +4584,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4607,7 +4607,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -4616,7 +4616,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4632,7 +4632,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4685,7 +4685,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4696,7 +4696,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4719,7 +4719,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4728,7 +4728,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4805,7 +4805,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.0.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=fix%2Ffn_bounds#2f28b49155b199a937a6aecce5350c3f4a4b64c8"
+source = "git+https://github.com/openvm-org/openvm.git?rev=dc48fafc7c789d867eed6c49b00a48ee8bbb272b#dc48fafc7c789d867eed6c49b00a48ee8bbb272b"
 dependencies = [
  "elf",
  "eyre",
@@ -5369,7 +5369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
 ]
 
 [[package]]
@@ -5506,9 +5506,9 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
 dependencies = [
  "proc-macro2",
  "syn 2.0.100",
@@ -5570,9 +5570,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -5643,7 +5643,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.25",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -5653,16 +5653,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.11"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbafbbdbb0f638fe3f35f3c56739f77a8a1d070cb25603226c83339b391472b"
+checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
 dependencies = [
  "bytes",
  "getrandom 0.3.2",
- "rand 0.9.1",
+ "rand 0.9.0",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.26",
+ "rustls 0.23.25",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -5730,12 +5730,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -5816,9 +5817,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -5943,7 +5944,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.26",
+ "rustls 0.23.25",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -6603,9 +6604,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.10.12"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+checksum = "a652edd001c53df0b3f96a36a8dc93fce6866988efc16808235653c6bcac8bf2"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -6723,9 +6724,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "once_cell",
  "ring",
@@ -6960,7 +6961,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "itoa",
  "memchr",
  "ryu",
@@ -7008,7 +7009,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7127,9 +7128,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
+checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 dependencies = [
  "serde",
 ]
@@ -7664,9 +7665,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.44.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
 dependencies = [
  "backtrace",
  "bytes",
@@ -7706,7 +7707,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.26",
+ "rustls 0.23.25",
  "tokio",
 ]
 
@@ -7741,7 +7742,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79e69d3b627db300ff956027cc6c3798cef26d22526befdfcd12feeb6d2257"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7775,7 +7776,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -7788,11 +7789,11 @@ version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.8.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.6",
+ "winnow 0.7.4",
 ]
 
 [[package]]
@@ -8520,9 +8521,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,6 @@ lto = "thin"
 [profile.profiling]
 inherits = "maxperf"
 debug = "full"
-strip = "none"
 
 [profile.maxperf]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ lto = "thin"
 [profile.profiling]
 inherits = "maxperf"
 debug = "full"
+strip = "none"
 
 [profile.maxperf]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,25 +129,25 @@ openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", ta
 # Note: the openvm-sdk commit does not need to be exactly the same as the `openvm` commit used in the guest program: as long as
 # the openvm-sdk commit doesn't change any guest libraries, they are compatible
 # This allows us to not update revm and openvm-kzg each time we change openvm-sdk
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
-openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", rev = "59391092804d54615790b90549b76a36e68a6f21", default-features = false }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,25 +129,25 @@ openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", ta
 # Note: the openvm-sdk commit does not need to be exactly the same as the `openvm` commit used in the guest program: as long as
 # the openvm-sdk commit doesn't change any guest libraries, they are compatible
 # This allows us to not update revm and openvm-kzg each time we change openvm-sdk
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
-openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", branch = "fix/fn_bounds", default-features = false }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
+openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", rev = "dc48fafc7c789d867eed6c49b00a48ee8bbb272b", default-features = false }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"


### PR DESCRIPTION
Set up guest profiling for reth-benchmark.
For an example run, see [guest flamegraph of block 21000000](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/fix/guest-flamegraph/reth-45f6c474dbf498da07089033be48f0702c17362b-1088dedf49d17357f0030f7d08efd9ae8d2a9e889861468ce321509a5b67fc1b.md).

Guest flamegraph of problematic reth blocks:
- [Block 22000279](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/fix/guest-flamegraph/reth-45f6c474dbf498da07089033be48f0702c17362b-a651194792af773b96affd90e5d1156abcc5ac2f684a369103a653cd88ca6353.md)
- [Block 22000471](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/fix/guest-flamegraph/reth-45f6c474dbf498da07089033be48f0702c17362b-2375951ce65f95eeacdce5c76eb501541fe0362b3f2de0f7b9b5cbf21859241e.md)
- [Block 22000818](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/fix/guest-flamegraph/reth-45f6c474dbf498da07089033be48f0702c17362b-6623fa73f2da2de52181e1072b39931c7e88dc27222317bca108329ce6eca6a7.md)

Resolves INT-3747 INT-3748