### PR TITLE
fix(ci): unset `RUSTFLAGS` for guest build

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -322,7 +322,7 @@ jobs:
         working-directory: bin/client-eth
         run: |
           GUEST_PROFILE=${{ steps.set-build-profiles.outputs.guest_profile }}
-          cargo openvm build --no-transpile --profile=$GUEST_PROFILE
+          RUSTFLAGS="" cargo openvm build --no-transpile --profile=$GUEST_PROFILE
           mkdir -p ../host/elf
           cp target/riscv32im-risc0-zkvm-elf/$GUEST_PROFILE/openvm-client-eth ../host/elf/
 


### PR DESCRIPTION
New `cargo-openvm` allows `RUSTFLAGS` so CI script needs to unset it