### PR TITLE
chore: add `prove-stark` mode

### DIFF
--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -18,9 +18,10 @@ on:
         options:
           - execute
           - tracegen
-          - prove
-          - prove-e2e
-        default: prove-e2e
+          - prove-app
+          - prove-stark
+          - prove-evm
+        default: prove-evm
       host_flamegraph:
         description: "Run target profiling benchmark for host flamegraph"
         type: boolean
@@ -126,7 +127,7 @@ jobs:
           TARGET_NAME=${{ needs.run-target-benchmark.outputs.metric_name }}
           TARGET_JSON=$TARGET_NAME/metrics.json
 
-          openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON 
+          openvm-prof --json-paths $TARGET_JSON --prev-json-paths $BASE_JSON
           MD_PATH=${TARGET_JSON%.json}.md
           # Inspired by https://github.com/rustls/rustls/blob/7159373401f253cbaacd276634508e0798a8849f/.github/workflows/icount-bench.yml#L37
           cat $MD_PATH >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -45,9 +45,10 @@ on:
         options:
           - execute
           - tracegen
-          - prove
-          - prove-e2e
-        default: prove-e2e
+          - prove-app
+          - prove-stark
+          - prove-evm
+        default: prove-evm
       profiling:
         type: choice
         required: false
@@ -121,8 +122,8 @@ on:
       mode:
         type: string
         required: false
-        description: Running mode, one of execute, tracegen, prove, or prove-e2e
-        default: prove-e2e
+        description: Running mode, one of {execute, tracegen, prove-app, prove-stark, prove-evm}
+        default: prove-evm
       profiling:
         type: string
         required: false
@@ -298,7 +299,7 @@ jobs:
           sudo apt install gnuplot
 
       - name: Setup halo2
-        if: ${{ (github.event.inputs.mode == 'prove-e2e') || (inputs.mode == 'prove-e2e') }}
+        if: ${{ (github.event.inputs.mode == 'prove-evm') || (inputs.mode == 'prove-evm') }}
         run: |
           bash openvm/extensions/native/recursion/trusted_setup_s3.sh
           PARAMS_DIR=$(pwd)/params
@@ -367,7 +368,7 @@ jobs:
           fi
           cat > run_benchmark.sh <<EOF
           ./target/$HOST_PROFILE/openvm-reth-benchmark-bin \
-            --$MODE --block-number $BLOCK_NUMBER --rpc-url $RPC_1 --cache-dir rpc-cache \
+            --mode $MODE --block-number $BLOCK_NUMBER --rpc-url $RPC_1 --cache-dir rpc-cache \
             --app-log-blowup ${{ inputs.app_log_blowup || github.event.inputs.app_log_blowup }} \
             --leaf-log-blowup ${{ inputs.leaf_log_blowup || github.event.inputs.leaf_log_blowup }} \
             --internal-log-blowup ${{ inputs.internal_log_blowup || github.event.inputs.internal_log_blowup || 2 }} \

--- a/.github/workflows/update-patches.yml
+++ b/.github/workflows/update-patches.yml
@@ -28,7 +28,7 @@ on:
         description: "Benchmark mode (if running benchmark)"
         type: string
         required: false
-        default: prove-e2e
+        default: prove-evm
       instance_family:
         description: "Instance family to use for benchmark"
         type: string
@@ -70,7 +70,7 @@ on:
         type: string
         required: false
         description: "Benchmark mode (if running benchmark)"
-        default: prove-e2e
+        default: prove-evm
       instance_family:
         type: string
         required: false
@@ -109,7 +109,7 @@ jobs:
   patch:
     name: "Update .cargo/config.toml and open a pull request"
     runs-on:
-      [ "runs-on", "runner=2cpu-linux-arm64", "run-id=${{ github.run_id }}" ]
+      ["runs-on", "runner=2cpu-linux-arm64", "run-id=${{ github.run_id }}"]
     outputs:
       branch_name: ${{ steps.create-branch.outputs.branch_name }}
       pr_number: ${{ steps.create-pr.outputs.pr_number }}
@@ -125,7 +125,7 @@ jobs:
       - name: Check out openvm repository
         uses: actions/checkout@v4
         with:
-          repository: 'openvm-org/openvm'
+          repository: "openvm-org/openvm"
           ref: ${{ steps.get-openvm-rev.outputs.result }}
 
       - name: Get STARK_BACKEND_REV from openvm
@@ -218,7 +218,7 @@ jobs:
     if: ${{ github.event.inputs.run_benchmark == 'true' || inputs.run_benchmark || github.event_name == 'schedule' }}
     uses: ./.github/workflows/reth-benchmark.yml
     with:
-      mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode || 'prove-e2e' }}
+      mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode || 'prove-evm' }}
       instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family || 'm8g.24xlarge' }}
       ref: ${{ needs.patch.outputs.branch_name }}
       tag: ${{ needs.patch.outputs.tag }}
@@ -231,7 +231,7 @@ jobs:
     if: ${{ github.event.inputs.host_flamegraph == 'true' || inputs.host_flamegraph || github.event_name == 'schedule' }}
     uses: ./.github/workflows/reth-benchmark.yml
     with:
-      mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode || 'prove-e2e' }}
+      mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode || 'prove-evm' }}
       instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family || 'm8g.24xlarge' }}
       ref: ${{ needs.patch.outputs.branch_name }}
       tag: ${{ needs.patch.outputs.tag }}
@@ -244,7 +244,7 @@ jobs:
     if: ${{ github.event.inputs.guest_flamegraph == 'true' || inputs.guest_flamegraph || github.event_name == 'schedule' }}
     uses: ./.github/workflows/reth-benchmark.yml
     with:
-      mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode || 'prove-e2e' }}
+      mode: ${{ inputs.benchmark_mode || github.event.inputs.benchmark_mode || 'prove-evm' }}
       instance_family: ${{ inputs.instance_family || github.event.inputs.instance_family || 'm8g.24xlarge' }}
       ref: ${{ needs.patch.outputs.branch_name }}
       tag: ${{ needs.patch.outputs.tag }}
@@ -253,7 +253,7 @@ jobs:
     secrets: inherit
 
   close-pr:
-    needs: [ patch, run-benchmark ]
+    needs: [patch, run-benchmark]
     if: |
       always() &&
       needs.patch.outputs.pr_number != '' &&

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,8 +3710,8 @@ dependencies = [
 
 [[package]]
 name = "openvm"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -3723,8 +3723,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3752,7 +3752,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3761,8 +3761,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-guest"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -3774,8 +3774,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-moduli-macros"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -3784,8 +3784,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-algebra-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -3798,8 +3798,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-prove"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -3835,8 +3835,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-benchmarks-utils"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -3850,8 +3850,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -3872,8 +3872,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-guest"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
@@ -3886,8 +3886,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-bigint-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -3901,8 +3901,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-build"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -3913,8 +3913,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -3945,8 +3945,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-derive"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -3955,8 +3955,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -3970,8 +3970,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-circuit-primitives-derive"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4017,8 +4017,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-continuations"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4033,7 +4033,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4042,8 +4042,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4073,8 +4073,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-guest"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4098,8 +4098,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-sw-macros"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4108,8 +4108,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-ecc-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4158,8 +4158,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4175,8 +4175,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-instructions-derive"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4184,8 +4184,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4210,8 +4210,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-guest"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-platform",
  "tiny-keccak",
@@ -4219,8 +4219,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-keccak256-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4233,16 +4233,16 @@ dependencies = [
 
 [[package]]
 name = "openvm-macros-common"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "openvm-mod-circuit-builder"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4287,8 +4287,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4314,8 +4314,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4338,8 +4338,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-compiler-derive"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4347,8 +4347,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-native-recursion"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4375,8 +4375,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4405,8 +4405,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-guest"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "group 0.13.0",
  "halo2curves-axiom",
@@ -4431,8 +4431,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-pairing-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4445,8 +4445,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-platform"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "getrandom 0.2.15",
  "libm",
@@ -4456,8 +4456,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-poseidon2-air"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -4564,8 +4564,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32-adapters"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4584,8 +4584,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4607,8 +4607,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-guest"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -4616,8 +4616,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-rv32im-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4632,8 +4632,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sdk"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "alloy-sol-types",
  "async-trait",
@@ -4685,8 +4685,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-air"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -4696,8 +4696,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-circuit"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4719,8 +4719,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-guest"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-platform",
  "sha2",
@@ -4728,8 +4728,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-sha256-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4806,8 +4806,8 @@ dependencies = [
 
 [[package]]
 name = "openvm-transpiler"
-version = "1.1.1-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?rev=8249e744b0ea1563129c97706e29705f8b55acce#8249e744b0ea1563129c97706e29705f8b55acce"
+version = "1.1.2"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.1.2#f0477ab8ee276bf102afb508cbb53a63efed9711"
 dependencies = [
  "elf",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,25 +129,25 @@ openvm-stark-sdk = { git = "https://github.com/openvm-org/stark-backend.git", ta
 # Note: the openvm-sdk commit does not need to be exactly the same as the `openvm` commit used in the guest program: as long as
 # the openvm-sdk commit doesn't change any guest libraries, they are compatible
 # This allows us to not update revm and openvm-kzg each time we change openvm-sdk
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
-openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", rev = "8249e744b0ea1563129c97706e29705f8b55acce", default-features = false }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
+openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.1.2", default-features = false }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To run the full end-to-end benchmark for EVM verification, run:
 ```bash
 RUSTFLAGS="-Ctarget-cpu=native" RUST_LOG=info OUTPUT_PATH="metrics.json" \
 cargo run --bin openvm-reth-benchmark --release -- \
---prove-e2e --block-number 21345144 --rpc-url $RPC_1 --cache-dir rpc-cache
+--mode prove-evm --block-number 21345144 --rpc-url $RPC_1 --cache-dir rpc-cache
 ```
 
 ### Summarizing Benchmark Results

--- a/run.sh
+++ b/run.sh
@@ -13,7 +13,7 @@ cd ../..
 
 mkdir -p rpc-cache
 source .env
-MODE=execute # can be execute, tracegen, prove, or prove-e2e
+MODE=execute # can be execute, tracegen, prove-app, prove-stark, or prove-evm
 PROFILE="release"
 FEATURES="bench-metrics,nightly-features,jemalloc"
 BLOCK_NUMBER=21882667
@@ -34,4 +34,4 @@ esac
 export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
 RUSTFLAGS=$RUSTFLAGS cargo build --bin openvm-reth-benchmark-bin --profile=$PROFILE --no-default-features --features=$FEATURES
 PARAMS_DIR="params"
-RUST_LOG="info,p3_=warn" OUTPUT_PATH="metrics.json" ./target/$PROFILE/openvm-reth-benchmark-bin --kzg-params-dir $PARAMS_DIR --$MODE --block-number $BLOCK_NUMBER --rpc-url $RPC_1 --cache-dir rpc-cache
+RUST_LOG="info,p3_=warn" OUTPUT_PATH="metrics.json" ./target/$PROFILE/openvm-reth-benchmark-bin --kzg-params-dir $PARAMS_DIR --mode $MODE --block-number $BLOCK_NUMBER --rpc-url $RPC_1 --cache-dir rpc-cache


### PR DESCRIPTION
refactor slightly so the mode uses an enum in the code, and now the benchmark binary takes `--mode <execute|tracegen|prove-app|prove-stark|prove-evm>`.

proof it works: https://github.com/axiom-crypto/openvm-reth-benchmark/blob/gh-pages/benchmarks-dispatch/refs/heads/chore/prove-stark/reth-64c3ca1b71adaaaa02f7aba4fe6b6879de6346af-e70ee8cc1966e79f7c55ba08641967cdab91eb0dc99f927778da648750cbd737.md