### PR TITLE
chore: remove .cargo patches

### DIFF
--- a/.cargo/config.template.toml
+++ b/.cargo/config.template.toml
@@ -50,6 +50,14 @@ openvm-rv32im-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", re
 openvm-rv32im-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-rv32im-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 
+# Guest Libs
+k256 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+p256 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+ruint = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-keccak256 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-sha2 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-pairing = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+
 # OpenVM
 # Extensions
 # [patch.crates-io]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,65 +1,65 @@
-# Copy to config.toml for local patches
-[net]
-git-fetch-with-cli = true
+# # Copy to config.toml for local patches
+# [net]
+# git-fetch-with-cli = true
 
-# [patch."https://github.com/openvm-org/stark-backend.git"]
-# openvm-stark-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.0.1" }
-# openvm-stark-sdk = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.0.1" }
+# # [patch."https://github.com/openvm-org/stark-backend.git"]
+# # openvm-stark-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.0.1" }
+# # openvm-stark-sdk = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.0.1" }
 
-[patch."https://github.com/openvm-org/openvm.git"]
-openvm-benchmarks-prove = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-# OpenVM
-openvm-sdk = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-cargo-openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-mod-circuit-builder = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-poseidon2-air = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-circuit-primitives = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-circuit-primitives-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-build = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-instructions = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-instructions-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-macros-common = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-platform = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# [patch."https://github.com/openvm-org/openvm.git"]
+# openvm-benchmarks-prove = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# # OpenVM
+# openvm-sdk = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# cargo-openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-mod-circuit-builder = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-poseidon2-air = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-circuit-primitives = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-circuit-primitives-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-build = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-instructions = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-instructions-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-macros-common = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-platform = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
 
-# Extensions
-openvm-algebra-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-algebra-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-algebra-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-algebra-moduli-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-algebra-complex-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-bigint-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-bigint-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-bigint-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-ecc-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-ecc-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-ecc-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-ecc-sw-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-keccak256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-keccak256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-keccak256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-sha256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-sha256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-sha256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-native-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-native-compiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-native-compiler-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-native-recursion = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-pairing-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-pairing-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-pairing-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-rv32-adapters = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-rv32im-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-rv32im-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-rv32im-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# # Extensions
+# openvm-algebra-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-algebra-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-algebra-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-algebra-moduli-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-algebra-complex-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-bigint-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-bigint-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-bigint-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-ecc-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-ecc-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-ecc-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-ecc-sw-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-keccak256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-keccak256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-keccak256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-sha256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-sha256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-sha256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-native-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-native-compiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-native-compiler-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-native-recursion = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-pairing-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-pairing-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-pairing-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-rv32-adapters = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-rv32im-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-rv32im-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-rv32im-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
 
-# Guest Libs
-k256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-p256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-ruint = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-keccak256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-sha2 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-openvm-pairing = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# # Guest Libs
+# k256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# p256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# ruint = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-keccak256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-sha2 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+# openvm-pairing = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,7 +4248,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -4261,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4290,7 +4290,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4300,7 +4300,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -4316,7 +4316,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -4328,7 +4328,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4342,7 +4342,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "clap",
  "derive-new 0.6.0",
@@ -4380,7 +4380,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4395,7 +4395,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4417,7 +4417,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -4426,7 +4426,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4441,7 +4441,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -4453,7 +4453,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4486,7 +4486,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4496,7 +4496,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4511,7 +4511,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4548,7 +4548,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4563,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4573,7 +4573,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4602,7 +4602,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4621,7 +4621,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4687,7 +4687,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4704,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -4713,7 +4713,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4739,7 +4739,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-platform",
 ]
@@ -4747,7 +4747,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4761,7 +4761,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "syn 2.0.103",
 ]
@@ -4769,7 +4769,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4815,7 +4815,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4843,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4867,7 +4867,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -4876,7 +4876,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4904,7 +4904,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -4914,7 +4914,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4945,7 +4945,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "halo2curves-axiom",
  "hex-literal",
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4980,7 +4980,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -4990,7 +4990,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -5096,7 +5096,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -5116,7 +5116,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -5150,7 +5150,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5166,7 +5166,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "alloy-sol-types 0.8.25",
  "async-trait",
@@ -5223,7 +5223,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -5234,7 +5234,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -5257,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-platform",
 ]
@@ -5265,7 +5265,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5343,7 +5343,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "elf",
  "eyre",
@@ -9357,38 +9357,3 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "cargo-openvm"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "k256"
-version = "0.13.4"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-keccak256"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-pairing"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-sha2"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "p256"
-version = "0.13.2"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "ruint"
-version = "1.14.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -275,7 +275,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2127,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "bytemuck",
  "getrandom 0.3.3",
@@ -2141,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint",
@@ -2167,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -2179,7 +2179,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2260,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2270,7 +2270,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-platform",
 ]
@@ -2278,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "openvm-kzg"
 version = "0.1.0-alpha"
-source = "git+https://github.com/axiom-crypto/openvm-kzg.git?rev=56751b25b4f18ba9988355faa288918db0ab3fde#56751b25b4f18ba9988355faa288918db0ab3fde"
+source = "git+https://github.com/axiom-crypto/openvm-kzg.git?branch=feat%2Fnew-execution#13442727360d76004c0df02654eb62b4a1ce89ac"
 dependencies = [
  "bls12_381",
  "hex",
@@ -2294,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "syn 2.0.101",
 ]
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "group",
  "hex-literal 0.4.1",
@@ -2349,7 +2349,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "hex-literal 0.4.1",
  "itertools 0.14.0",
@@ -2369,7 +2369,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -2400,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-sha256-guest",
  "sha2",
@@ -2419,7 +2419,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "openvm-platform",
 ]
@@ -3227,7 +3227,7 @@ dependencies = [
 [[package]]
 name = "revm"
 version = "24.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "revm-bytecode",
  "revm-context",
@@ -3245,7 +3245,7 @@ dependencies = [
 [[package]]
 name = "revm-bytecode"
 version = "4.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "bitvec",
  "once_cell",
@@ -3257,7 +3257,7 @@ dependencies = [
 [[package]]
 name = "revm-context"
 version = "5.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "cfg-if",
  "derive-where",
@@ -3272,7 +3272,7 @@ dependencies = [
 [[package]]
 name = "revm-context-interface"
 version = "5.0.0"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3287,7 +3287,7 @@ dependencies = [
 [[package]]
 name = "revm-database"
 version = "4.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "alloy-eips",
  "revm-bytecode",
@@ -3300,7 +3300,7 @@ dependencies = [
 [[package]]
 name = "revm-database-interface"
 version = "4.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "auto_impl",
  "revm-primitives",
@@ -3311,7 +3311,7 @@ dependencies = [
 [[package]]
 name = "revm-handler"
 version = "5.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "auto_impl",
  "revm-bytecode",
@@ -3328,7 +3328,7 @@ dependencies = [
 [[package]]
 name = "revm-inspector"
 version = "5.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "auto_impl",
  "revm-context",
@@ -3342,7 +3342,7 @@ dependencies = [
 [[package]]
 name = "revm-interpreter"
 version = "20.0.0"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "revm-bytecode",
  "revm-context-interface",
@@ -3353,7 +3353,7 @@ dependencies = [
 [[package]]
 name = "revm-precompile"
 version = "21.0.0"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3378,7 +3378,7 @@ dependencies = [
 [[package]]
 name = "revm-primitives"
 version = "19.1.0"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -3388,7 +3388,7 @@ dependencies = [
 [[package]]
 name = "revm-state"
 version = "4.0.1"
-source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm#9f89009d065361f28d2984cbf50d670c7278719a"
+source = "git+https://github.com/axiom-crypto/revm?branch=v75-openvm-new-exec#9e79f2b3332e04ea6cf5377552d630e6ef699918"
 dependencies = [
  "bitflags",
  "revm-bytecode",
@@ -3440,7 +3440,7 @@ dependencies = [
 [[package]]
 name = "ruint"
 version = "1.14.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -3467,7 +3467,7 @@ dependencies = [
 [[package]]
 name = "ruint-macro"
 version = "1.2.1"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"
 
 [[package]]
 name = "rustc-hash"
@@ -4554,174 +4554,4 @@ dependencies = [
 [[patch.unused]]
 name = "p256"
 version = "0.13.2"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "cargo-openvm"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-algebra-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-algebra-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-benchmarks-prove"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-bigint-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-bigint-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-build"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-circuit-derive"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-circuit-primitives"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-circuit-primitives-derive"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-ecc-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-ecc-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-instructions"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-instructions-derive"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-keccak256"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-keccak256-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-keccak256-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-mod-circuit-builder"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-native-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-native-compiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-native-compiler-derive"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-native-recursion"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-pairing-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-pairing-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-poseidon2-air"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-rv32-adapters"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-rv32im-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-rv32im-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-sdk"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-sha256-circuit"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-sha256-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "openvm-transpiler"
-version = "1.3.0-rc.0"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
-
-[[patch.unused]]
-name = "p256"
-version = "0.13.2"
-source = "git+ssh://git@github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#5eba5136c620a851e472168ac902d049e216f620"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#29e11c363b8395089037d6ecf06d2a6d9ed6c2a6"

--- a/bin/client-eth/Cargo.toml
+++ b/bin/client-eth/Cargo.toml
@@ -39,17 +39,17 @@ kzg-intrinsics = [
 ] # uses OpenVM BLS12-381 intrinsic functions
 
 [patch.crates-io]
-revm = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-revm-primitives = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-revm-interpreter = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-revm-precompile = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-revm-database = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-revm-database-interface = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-revm-state = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-revm-bytecode = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm" }
-k256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-p256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
-ruint = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+revm = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+revm-primitives = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+revm-interpreter = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+revm-precompile = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+revm-database = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+revm-database-interface = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+revm-state = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+revm-bytecode = { git = "https://github.com/axiom-crypto/revm", branch = "v75-openvm-new-exec" }
+k256 = { git = "https://github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+p256 = { git = "https://github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
+ruint = { git = "https://github.com/openvm-org/openvm.git", branch = "feat/new-execution" }
 # k256 = { path = "../../../openvm-org/openvm/guest-libs/k256" }
 # p256 = { path = "../../../openvm-org/openvm/guest-libs/p256" }
 # ruint = { path = "../../../openvm-org/openvm/guest-libs/ruint" }


### PR DESCRIPTION
Uses `openvm-kzg:feat/new-execution` and `revm:v75-openvm-new-exec`

workflow on just execute: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/15861742727