### PR TITLE
feat(new-execution): upload execute profile to firefox

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -486,6 +486,41 @@ jobs:
           echo "</details>" >> $MD_PATH
           echo "" >> $MD_PATH
 
+      - name: Generate samply profile artifacts
+        if: ${{ inputs.profiling == 'host' || github.event.inputs.profiling == 'host' }}
+        run: |
+          cargo install --git https://github.com/mstange/samply.git samply --force
+
+          mkdir -p samply_profile
+          SAMPLY_PROFILE_PATH=samply_profile
+
+          samply import perf.data --presymbolicate --save-only --output $SAMPLY_PROFILE_PATH/profile.json.gz
+          echo "SAMPLY_PROFILE_PATH=${SAMPLY_PROFILE_PATH}" >> $GITHUB_ENV
+
+          s5cmd cp $SAMPLY_PROFILE_PATH/profile.json.gz ${{ env.S3_SAMPLY_PROFILE_PATH }}/${METRIC_NAME}/profile.json.gz
+
+          MODE=${{ inputs.mode || github.event.inputs.mode }}
+          if [[ "$MODE" == "execute" || "$MODE" == "execute-metered" ]]; then
+            FIREFOX_PROFILER_TOKEN=$(curl 'https://api.profiler.firefox.com/compressed-store' -X POST -H 'Accept: application/vnd.firefox-profiler+json;version=1.0' --data-binary @"$SAMPLY_PROFILE_PATH/profile.json.gz" | python3 -c "import sys,base64,json; t=sys.stdin.read().strip().split('.')[1]; t+='='*(4-len(t)%4)if len(t)%4 else''; print(json.loads(base64.urlsafe_b64decode(t))['profileToken'])")
+
+            if [ -n "$FIREFOX_PROFILER_TOKEN" ]; then
+              FIREFOX_PROFILER_URL="https://profiler.firefox.com/public/$FIREFOX_PROFILER_TOKEN"
+              echo "FIREFOX_PROFILER_URL=$FIREFOX_PROFILER_URL" >> $GITHUB_ENV
+              echo "" >> $MD_PATH
+              echo "**[Firefox Profiler]($FIREFOX_PROFILER_URL)**" >> $MD_PATH
+            fi
+          fi
+          echo "S3_SAMPLY_PROFILE_PATH=${S3_SAMPLY_PROFILE_PATH}" >> $GITHUB_ENV
+
+      - name: Upload samply profile artifacts
+        if: ${{ inputs.profiling == 'host' || github.event.inputs.profiling == 'host' }}
+        id: upload-samply-profile-artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-metric-name.outputs.name }}-samply-profile
+          path: ${{ env.SAMPLY_PROFILE_PATH }}
+          retention-days: 1
+
       - name: Add benchmark metadata to markdown
         run: |
           COMMIT_URL=https://github.com/${{ github.repository }}/commit/${current_sha}
@@ -505,30 +540,6 @@ jobs:
           S3_MD_PATH="${{ env.S3_PATH }}/${METRIC_NAME}.md"
           s5cmd cp $MD_PATH $S3_MD_PATH
           echo "S3_MD_PATH=${S3_MD_PATH}" >> $GITHUB_ENV
-
-      - name: Generate samply profile artifacts
-        if: ${{ inputs.profiling == 'host' || github.event.inputs.profiling == 'host' }}
-        run: |
-          cargo install --git https://github.com/mstange/samply.git samply --force
-
-          mkdir -p samply_profile
-          SAMPLY_PROFILE_PATH=samply_profile
-
-          samply import perf.data --presymbolicate --save-only --output $SAMPLY_PROFILE_PATH/profile.json
-          echo "SAMPLY_PROFILE_PATH=${SAMPLY_PROFILE_PATH}" >> $GITHUB_ENV
-
-          s5cmd cp $SAMPLY_PROFILE_PATH/profile.json ${{ env.S3_SAMPLY_PROFILE_PATH }}/${METRIC_NAME}/profile.json
-          s5cmd cp $SAMPLY_PROFILE_PATH/profile.syms.json ${{ env.S3_SAMPLY_PROFILE_PATH }}/${METRIC_NAME}/profile.syms.json
-          echo "S3_SAMPLY_PROFILE_PATH=${S3_SAMPLY_PROFILE_PATH}" >> $GITHUB_ENV
-
-      - name: Upload samply profile artifacts
-        if: ${{ inputs.profiling == 'host' || github.event.inputs.profiling == 'host' }}
-        id: upload-samply-profile-artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.set-metric-name.outputs.name }}-samply-profile
-          path: ${{ env.SAMPLY_PROFILE_PATH }}
-          retention-days: 1
 
       ### Update gh-pages
       - uses: actions/checkout@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,7 +4257,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -4270,11 +4270,12 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
  "eyre",
+ "halo2curves-axiom",
  "itertools 0.14.0",
  "num-bigint 0.4.6",
  "num-traits",
@@ -4298,7 +4299,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4308,7 +4309,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -4324,7 +4325,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -4336,7 +4337,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4350,7 +4351,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "clap",
  "derive_more 1.0.0",
@@ -4386,7 +4387,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4401,7 +4402,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4423,7 +4424,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -4432,7 +4433,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4447,7 +4448,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -4459,7 +4460,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "backtrace",
  "dashmap",
@@ -4492,7 +4493,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -4503,7 +4504,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4518,7 +4519,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4555,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4570,7 +4571,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4580,7 +4581,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4608,7 +4609,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4627,7 +4628,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4637,7 +4638,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4693,7 +4694,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4710,7 +4711,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -4719,7 +4720,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4743,7 +4744,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-platform",
 ]
@@ -4751,7 +4752,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4765,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "syn 2.0.103",
 ]
@@ -4773,7 +4774,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint 0.4.6",
@@ -4817,7 +4818,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4843,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -4867,7 +4868,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -4876,7 +4877,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -4904,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -4914,7 +4915,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -4942,7 +4943,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "halo2curves-axiom",
  "hex-literal",
@@ -4963,7 +4964,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -4976,7 +4977,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -4986,7 +4987,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -5094,7 +5095,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -5111,7 +5112,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -5133,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -5143,7 +5144,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5159,7 +5160,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "alloy-sol-types 0.8.25",
  "bitcode",
@@ -5215,7 +5216,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -5226,7 +5227,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -5248,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-platform",
 ]
@@ -5256,7 +5257,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5335,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "elf",
  "eyre",

--- a/bin/client-eth/Cargo.lock
+++ b/bin/client-eth/Cargo.lock
@@ -1807,7 +1807,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2127,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.16",
@@ -2142,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2152,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint",
@@ -2168,7 +2168,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -2180,7 +2180,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -2232,7 +2232,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2242,7 +2242,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-platform",
 ]
@@ -2295,7 +2295,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "syn 2.0.101",
 ]
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "group",
  "hex-literal 0.4.1",
@@ -2350,7 +2350,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "hex-literal 0.4.1",
  "itertools 0.14.0",
@@ -2370,7 +2370,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -2411,7 +2411,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-sha256-guest",
  "sha2",
@@ -2420,7 +2420,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.4.0-rc.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "openvm-platform",
 ]
@@ -3441,7 +3441,7 @@ dependencies = [
 [[package]]
 name = "ruint"
 version = "1.14.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "ruint-macro"
 version = "1.2.1"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"
 
 [[package]]
 name = "rustc-hash"
@@ -4555,4 +4555,4 @@ dependencies = [
 [[patch.unused]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#b269dbbacf2ed2cfca8d41ab61e4af8d5dc4e6ff"
+source = "git+https://github.com/openvm-org/openvm.git?branch=feat%2Fnew-execution#1643eba80ccc869eabda4e1f673c3304d65b3327"


### PR DESCRIPTION
- store gzipped `profile.json.gz`
- remove `profile.syms.json` since it is no longer generated by samply
- upload profile to firefox profiler and add link to benchmark markdown (only for `execute` and `execute-metered`)

[Sample workflow](https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/16505799915)