### PR TITLE
chore: comment state root and fix handling of empty accounts

### DIFF
--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Bloom;
 use alloy_provider::{network::Ethereum, Provider};
 use eyre::{eyre, Ok};
 use openvm_client_executor::io::ClientExecutorInput;
-use openvm_mpt::{state::HashedPostState, EthereumState};
+use openvm_mpt::EthereumState;
 use openvm_primitives::account_proof::eip1186_proof_to_account_proof;
 use openvm_rpc_db::RpcDb;
 use reth_chainspec::MAINNET;

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -150,18 +150,18 @@ impl<P: Provider<Ethereum> + Clone> HostExecutor<P> {
             &after_storage_proofs.iter().map(|item| (item.address, item.clone())).collect(),
         )?;
 
-        // Verify the state root.
-        tracing::info!("verifying the state root");
-        let state_root = {
-            let mut mutated_state = state.clone();
-            let post_state = HashedPostState::from_bundle_state(&executor_outcome.bundle.state);
-            // executor_outcome.hash_state_slow());
-            mutated_state.update(&post_state);
-            mutated_state.state_root()
-        };
-        if state_root != current_block.state_root {
-            eyre::bail!("mismatched state root");
-        }
+        // Skip state root verification for now.
+        // It works with Alchemy but for some reason not with Quicknode.
+        // It is checked on the client (guest) side  and works with all providers.
+        // tracing::info!("verifying the state root");
+        // let state_root = {
+        //     let mut mutated_state = state.clone();
+        //     mutated_state.update_from_bundle_state(&executor_outcome.bundle);
+        //     mutated_state.state_root()
+        // };
+        // if state_root != current_block.state_root {
+        //     eyre::bail!("mismatched state root");
+        // }
 
         // Derive the block header.
         //
@@ -181,10 +181,10 @@ impl<P: Provider<Ethereum> + Clone> HostExecutor<P> {
 
         // Log the result.
         tracing::info!(
-            "successfully executed block: block_number={}, block_hash={}, state_root={}",
+            "successfully executed block: block_number={}, block_hash={}",
             current_block.header.number,
             header.hash_slow(),
-            state_root
+            // state_root
         );
 
         // Fetch the parent headers needed to constrain the BLOCKHASH opcode.

--- a/crates/executor/host/src/lib.rs
+++ b/crates/executor/host/src/lib.rs
@@ -152,16 +152,7 @@ impl<P: Provider<Ethereum> + Clone> HostExecutor<P> {
 
         // Skip state root verification for now.
         // It works with Alchemy but for some reason not with Quicknode.
-        // It is checked on the client (guest) side  and works with all providers.
-        // tracing::info!("verifying the state root");
-        // let state_root = {
-        //     let mut mutated_state = state.clone();
-        //     mutated_state.update_from_bundle_state(&executor_outcome.bundle);
-        //     mutated_state.state_root()
-        // };
-        // if state_root != current_block.state_root {
-        //     eyre::bail!("mismatched state root");
-        // }
+        // It is checked on the client (guest) side and works with all providers.
 
         // Derive the block header.
         //
@@ -181,10 +172,10 @@ impl<P: Provider<Ethereum> + Clone> HostExecutor<P> {
 
         // Log the result.
         tracing::info!(
-            "successfully executed block: block_number={}, block_hash={}",
+            "successfully executed block: block_number={}, block_hash={}, state_root={}",
             current_block.header.number,
             header.hash_slow(),
-            // state_root
+            current_block.state_root
         );
 
         // Fetch the parent headers needed to constrain the BLOCKHASH opcode.

--- a/crates/storage/rpc-db/src/lib.rs
+++ b/crates/storage/rpc-db/src/lib.rs
@@ -174,6 +174,11 @@ impl<P: Provider<Ethereum> + Clone> DatabaseRef for RpcDb<P> {
             tokio::task::block_in_place(|| handle.block_on(self.fetch_account_info(address)));
         let account_info =
             result.map_err(|e| ProviderError::Database(DatabaseError::Other(e.to_string())))?;
+
+        if account_info.eq(&AccountInfo::default()) {
+            return Ok(None);
+        }
+
         Ok(Some(account_info))
     }
 

--- a/crates/storage/rpc-db/src/lib.rs
+++ b/crates/storage/rpc-db/src/lib.rs
@@ -75,7 +75,7 @@ impl<P: Provider<Ethereum> + Clone> RpcDb<P> {
         let account_info = AccountInfo {
             nonce: proof.nonce,
             balance: proof.balance,
-            code_hash: proof.code_hash,
+            code_hash: bytecode.hash_slow(),
             code: Some(bytecode.clone()),
         };
 

--- a/crates/storage/witness-db/src/lib.rs
+++ b/crates/storage/witness-db/src/lib.rs
@@ -23,7 +23,13 @@ impl DatabaseRef for WitnessDb {
     fn basic_ref(&self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         // Even absent accounts are loaded as `None`, so if an entry is missing from `HashMap` we
         // need to panic. Otherwise it would be interpreted by `revm` as an uninitialized account.
-        Ok(Some(self.accounts.get(&address).cloned().unwrap()))
+        let account = self.accounts.get(&address).cloned().unwrap();
+
+        if account.eq(&AccountInfo::default()) {
+            return Ok(None);
+        }
+
+        Ok(Some(account))
     }
 
     fn code_by_hash_ref(&self, _code_hash: B256) -> Result<Bytecode, Self::Error> {


### PR DESCRIPTION
This PR fixes how empty accounts are handled by the `RpcDb`. The issue came up when trying to generate an input for a block that had a transaction with an EIP-7702 delegation. Specifically, the following command currently fails on `feat/new-execution`

```rust
cargo run -- --block-number 23120965 --mode make-input --rpc-url $RPC_URL_1 --input-path ./input
```

The cause of the issue is surrounding EIP-7702 delegation refunds. Upfront, a delegation transaction is charged `25_000` gas per delegation. If the delegating account was already initialized (for example, it had a balance), the transactor will receive a `12_500` gas refund. The issue was that during input generation, _all_ transactors were receiving the gas refund, even if the delegating account was _un_initialized. This led to the block above expending `12_500` gas below what was expected.

## The Fix

The logic for whether or not a EIP-7702 delegation is eligible for a refund is [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/handler/src/pre_execution.rs#L232-L238). The problem is on this line

```rust
let loaded_not_existing = authority_acc.is_loaded_as_not_existing();
```

This line checks that the status of the `authority_acc` is `LoadedAsNotExisting`. All the statuses for an account can be found [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/state/src/lib.rs#L204-L220). Accounts marked as `LoadedAsNotExisting` cannot receive an EIP-7702 refund and, as I'll highlight below, the problem was that accounts that should not be getting refunds were not being given the `LoadedAsNotExisting` status.

Now, how is this status actually determined? The actual status of our `authority_acc` is loaded [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/handler/src/pre_execution.rs#L217).
- Which calls into [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/context/src/journal.rs#L219-L224)
- Then [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/context/src/journal/inner.rs#L511), [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/context/src/journal/inner.rs#L521), and finally [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/context/src/journal/inner.rs#L532).

For our problematic transaction, we go down the `Entry::Vacant` [branch](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/context/src/journal/inner.rs#L548C13-L548C26), and the call `db.basic` [here](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/context/src/journal/inner.rs#L549). This calls back to the cache db we initialized [here](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/feat/new-execution/crates/executor/host/src/lib.rs#L61) and end up in this [fn](https://github.com/bluealloy/revm/blob/f7f91628a69bc86cc29c0bf7d84432df12756260/crates/database/src/in_memory_db.rs#L228). In this fn, `Entry::Vacant` is the problematic branch. We call `basic_ref` on the `RpcDb` we initialized [here](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/feat/new-execution/crates/executor/host/src/lib.rs#L60) and end up in this [fn](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/feat/new-execution/crates/storage/rpc-db/src/lib.rs#L169). The issue is this returns `Some()` even for an uninitialized account, which means it won't get a status of `LoadedAsNotExisting` meaning it will be given a refund. To get the status of `LoadedAsNotExisting`, this function needs to return an `Ok(None)`.

So the fix was to check if the account was empty, and return `Ok(None)` if it was.

This PR also comments out a state root check in the host. 