### PR TITLE
ci: cache cargo-openvm

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -333,10 +333,24 @@ jobs:
           path: bin/host/elf/openvm-client-eth
           key: ${{ steps.set-cache-keys.outputs.elf_cache_key }}
 
+      - name: Restore cargo-openvm from cache
+        id: cache-cargo-openvm-restore
+        uses: runs-on/cache/restore@v4
+        with:
+          path: ~/.cargo/bin/cargo-openvm
+          key: cargo-openvm-${{ steps.get-openvm-rev.outputs.result }}-${{ runner.os }}-${{ runner.arch }}
+
       - name: Install cargo-openvm
-        if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true'
+        if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true' && steps.cache-cargo-openvm-restore.outputs.cache-hit != 'true'
         run: |
           cargo install --git https://github.com/openvm-org/openvm.git --rev ${{ steps.get-openvm-rev.outputs.result }} --locked --force cargo-openvm
+
+      - name: Save cargo-openvm to cache
+        if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true' && steps.cache-cargo-openvm-restore.outputs.cache-hit != 'true'
+        uses: runs-on/cache/save@v4
+        with:
+          path: ~/.cargo/bin/cargo-openvm
+          key: ${{ steps.cache-cargo-openvm-restore.outputs.cache-primary-key }}
       - name: Build Guest ELF
         if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true'
         working-directory: bin/client-eth


### PR DESCRIPTION
Installing `cargo-openvm` from scratch takes 10+ minutes. This PR adds a repository-wide s3 cache with `{ openvm-rev}-{os}-{arch}` key.

Benchmark run: https://github.com/axiom-crypto/openvm-reth-benchmark/actions/runs/17499467716