### PR TITLE
feat: Profiling Leaf/Internal.0 Alone

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -48,6 +48,7 @@ on:
           - prove-app
           - prove-stark
           - prove-evm
+          - generate-fixtures
         default: prove-stark
       profiling:
         type: choice
@@ -167,6 +168,7 @@ on:
 
 env:
   S3_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/results
+  S3_FIXTURE_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/fixtures
   S3_METRICS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/metrics
   S3_FLAMEGRAPHS_PATH: s3://axiom-public-data-sandbox-us-east-1/benchmark/github/flamegraphs
   S3_FLAMEGRAPHS_URL: https://axiom-public-data-sandbox-us-east-1.s3.us-east-1.amazonaws.com/benchmark/github/flamegraphs
@@ -388,12 +390,21 @@ jobs:
         run: |
           mkdir -p rpc-cache
           mkdir -p .bench_metrics
+          mkdir -p fixtures
           RPC_1=${{ secrets.RPC_URL_1 }}
           MODE=${{ inputs.mode || github.event.inputs.mode }}
           BLOCK_NUMBER=${{ inputs.block_number || github.event.inputs.block_number }}
+          echo "BLOCK_NUMBER=${BLOCK_NUMBER}" >> $GITHUB_ENV
+          APP_LOG_BLOWUP=${{ inputs.app_log_blowup || github.event.inputs.app_log_blowup }}
+          LEAF_LOG_BLOWUP=${{ inputs.leaf_log_blowup || github.event.inputs.leaf_log_blowup }}
+          echo "APP_LOG_BLOWUP=${APP_LOG_BLOWUP}" >> $GITHUB_ENV
+          echo "LEAF_LOG_BLOWUP=${LEAF_LOG_BLOWUP}" >> $GITHUB_ENV
           HOST_PROFILE=${{ steps.set-build-profiles.outputs.host_profile }}
           if [[ "${{ inputs.profiling || github.event.inputs.profiling }}" == "guest" ]]; then
             OPTIONAL_ARGS="${OPTIONAL_ARGS} --profiling"
+          fi          
+          if [[ "${{ inputs.mode || github.event.inputs.mode }}" == "generate-fixtures" ]]; then
+            FIXTURES_PATH="--fixtures-path ./fixtures/"
           fi
           cat > run_benchmark.sh <<EOF
           ./target/$HOST_PROFILE/openvm-reth-benchmark-bin \
@@ -406,7 +417,7 @@ jobs:
             --segment-max-cells ${{ inputs.segment_max_cells || github.event.inputs.segment_max_cells }} \
             --num-children-leaf ${{ inputs.num_children_leaf || github.event.inputs.num_children_leaf || 1 }} \
             --num-children-internal ${{ inputs.num_children_internal || github.event.inputs.num_children_internal }} \
-            $OPTIONAL_ARGS
+            $OPTIONAL_ARGS $FIXTURES_PATH
           EOF
           chmod +x run_benchmark.sh
 
@@ -557,6 +568,11 @@ jobs:
           S3_MD_PATH="${{ env.S3_PATH }}/${METRIC_NAME}.md"
           s5cmd cp $MD_PATH $S3_MD_PATH
           echo "S3_MD_PATH=${S3_MD_PATH}" >> $GITHUB_ENV
+
+      - name: Upload fixtures
+        if: ${{ inputs.mode == 'generate-fixtures' || github.event.inputs.mode == 'generate-fixtures' }}
+        run: |
+          s5cmd cp "./fixtures/*" "${S3_FIXTURE_PATH}/reth-app${APP_LOG_BLOWUP}-leaf${LEAF_LOG_BLOWUP}-${BLOCK_NUMBER}/"
 
       ### Update gh-pages
       - uses: actions/checkout@v4

--- a/.github/workflows/run-benchmark-v2.yml
+++ b/.github/workflows/run-benchmark-v2.yml
@@ -78,7 +78,7 @@ jobs:
             mkdir -p params
 
             # Build the benchmark binary
-            export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1,abort_conf:true"
+            export JEMALLOC_SYS_WITH_MALLOC_CONF="retain:true,background_thread:true,metadata_thp:always,thp:always,dirty_decay_ms:10000,muzzy_decay_ms:10000,abort_conf:true"
             cargo build --bin openvm-reth-benchmark-bin --profile=release --no-default-features --features="bench-metrics,nightly-features,jemalloc,evm-verify"
 
             # Generate input data

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -451,7 +451,7 @@ checksum = "64b728d511962dda67c1bc7ea7c03736ec275ed2cf4c35d9585298ac9ccf3b73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -573,7 +573,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -587,7 +587,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -604,7 +604,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "syn-solidity 0.8.25",
  "tiny-keccak",
 ]
@@ -622,7 +622,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "syn-solidity 1.2.0",
  "tiny-keccak",
 ]
@@ -641,7 +641,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.103",
+ "syn 2.0.102",
  "syn-solidity 0.8.25",
 ]
 
@@ -657,7 +657,7 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "syn-solidity 1.2.0",
 ]
 
@@ -980,7 +980,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1018,7 +1018,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1107,7 +1107,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1183,7 +1183,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1224,7 +1224,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1353,7 +1353,7 @@ checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1498,7 +1498,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -1631,9 +1631,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
 dependencies = [
  "jobserver",
  "libc",
@@ -1733,7 +1733,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2025,7 +2025,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2036,7 +2036,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2093,7 +2093,7 @@ checksum = "d150dea618e920167e5973d70ae6ece4385b7164e0d799fe7c122dd0a5d912ad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2104,18 +2104,18 @@ checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510c292c8cf384b1a340b816a9a6cf2599eb8f566a44949024af88418000c50b"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2128,7 +2128,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2157,7 +2157,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "unicode-xid",
 ]
 
@@ -2170,7 +2170,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "unicode-xid",
 ]
 
@@ -2261,7 +2261,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2312,7 +2312,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2391,7 +2391,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2403,7 +2403,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2414,7 +2414,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2818,7 +2818,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2910,7 +2910,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -2921,9 +2921,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glam"
-version = "0.30.4"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a99dbe56b72736564cfa4b85bf9a33079f16ae8b74983ab06af3b1a3696b11"
+checksum = "6b46b9ca4690308844c644e7c634d68792467260e051c8543e0c7871662b3ba7"
 
 [[package]]
 name = "glob"
@@ -3376,7 +3376,7 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.28",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -3580,7 +3580,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3811,9 +3811,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmimalloc-sys"
-version = "0.1.43"
+version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf88cd67e9de251c1781dbe2f641a1a3ad66eaae831b8a2c38fbdc5ddae16d4d"
+checksum = "ec9d6fac27761dabcd4ee73571cdb06b7022dc99089acbe5435691edffaac0f4"
 dependencies = [
  "cc",
  "libc",
@@ -3941,7 +3941,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -3981,9 +3981,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "843a98750cd611cc2965a8213b53b43e715f13c37a9e096c6408e69990961db7"
 dependencies = [
  "libc",
 ]
@@ -4042,9 +4042,9 @@ dependencies = [
 
 [[package]]
 name = "mimalloc"
-version = "0.1.47"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1791cbe101e95af5764f06f20f6760521f7158f69dbf9d6baf941ee1bf6bc40"
+checksum = "995942f432bbb4822a7e9c3faa87a695185b0d09273ba85f097b54f4e458f2af"
 dependencies = [
  "libmimalloc-sys",
 ]
@@ -4290,7 +4290,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4455,7 +4455,7 @@ source = "git+https://github.com/openvm-org/openvm.git?branch=main#d35aac5d1037d
 dependencies = [
  "openvm-macros-common",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4483,7 +4483,7 @@ dependencies = [
  "num-prime",
  "openvm-macros-common",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4651,7 +4651,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4679,7 +4679,7 @@ source = "git+https://github.com/openvm-org/openvm.git?branch=main#d35aac5d1037d
 dependencies = [
  "itertools 0.14.0",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4787,7 +4787,7 @@ source = "git+https://github.com/openvm-org/openvm.git?branch=main#d35aac5d1037d
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4848,7 +4848,7 @@ source = "git+https://github.com/openvm-org/openvm.git?branch=main#d35aac5d1037d
 dependencies = [
  "openvm-macros-common",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4920,7 +4920,7 @@ version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?branch=main#d35aac5d1037da76e43227ba0c4c3c632177cd3d"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -4978,7 +4978,7 @@ name = "openvm-macros-common"
 version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?branch=main#d35aac5d1037da76e43227ba0c4c3c632177cd3d"
 dependencies = [
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5115,7 +5115,7 @@ version = "1.4.0"
 source = "git+https://github.com/openvm-org/openvm.git?branch=main#d35aac5d1037da76e43227ba0c4c3c632177cd3d"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -5277,6 +5277,7 @@ dependencies = [
  "alloy-rpc-client",
  "alloy-transport",
  "bincode 2.0.1",
+ "bitcode",
  "clap",
  "derive_more 1.0.0",
  "dotenv",
@@ -5304,7 +5305,7 @@ dependencies = [
  "reth-primitives",
  "serde",
  "serde_json",
- "toml 0.9.2",
+ "toml 0.9.5",
  "tracing",
  "tracing-subscriber 0.3.20",
  "url",
@@ -6028,7 +6029,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6139,7 +6140,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6150,9 +6151,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -6200,7 +6201,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6229,7 +6230,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6341,12 +6342,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6400,7 +6401,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6420,7 +6421,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -6478,7 +6479,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.27",
  "socket2",
  "thiserror 2.0.12",
  "tokio",
@@ -6498,7 +6499,7 @@ dependencies = [
  "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
- "rustls 0.23.28",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.12",
@@ -6663,9 +6664,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -6698,7 +6699,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -6791,7 +6792,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.28",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -6855,7 +6856,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7576,9 +7577,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "ring",
@@ -7682,7 +7683,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7690,6 +7691,18 @@ name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7811,7 +7824,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -7869,16 +7882,17 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf65a400f8f66fb7b0552869ad70157166676db75ed8181f8104ea91cf9d0b42"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.9.0",
- "schemars",
+ "schemars 0.9.0",
+ "schemars 1.0.4",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7888,14 +7902,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81679d9ed988d5e9a5e6531dc3f2c28efbd639cbd1dfb628df08edea6004da77"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8011,9 +8025,12 @@ checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -8173,7 +8190,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8186,7 +8203,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8241,9 +8258,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8259,7 +8276,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8271,7 +8288,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8297,7 +8314,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8369,7 +8386,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8380,7 +8397,7 @@ checksum = "5c89e72a01ed4c579669add59014b9a524d609c0c88c6a585ce37485879f6ffb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "test-case-core",
 ]
 
@@ -8410,7 +8427,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8421,7 +8438,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8432,11 +8449,12 @@ checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -8568,7 +8586,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -8587,7 +8605,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.28",
+ "rustls 0.23.27",
  "tokio",
 ]
 
@@ -8643,9 +8661,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -8703,9 +8721,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow 0.7.11",
 ]
@@ -8786,7 +8804,7 @@ checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9069,7 +9087,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "wasm-bindgen-shared",
 ]
 
@@ -9104,7 +9122,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9219,7 +9237,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9230,14 +9248,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-result"
@@ -9489,7 +9507,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -9510,7 +9528,7 @@ checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9530,7 +9548,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
  "synstructure",
 ]
 
@@ -9551,7 +9569,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]
@@ -9584,7 +9602,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.102",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5328,6 +5328,7 @@ name = "openvm-reth-verifier-bench"
 version = "0.1.0"
 dependencies = [
  "bitcode",
+ "clap",
  "openvm-circuit",
  "openvm-continuations",
  "openvm-native-circuit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5324,6 +5324,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "openvm-reth-verifier-bench"
+version = "0.1.0"
+dependencies = [
+ "bitcode",
+ "openvm-circuit",
+ "openvm-continuations",
+ "openvm-native-circuit",
+ "openvm-native-recursion",
+ "openvm-sdk",
+ "openvm-stark-sdk",
+]
+
+[[package]]
 name = "openvm-rpc-db"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/storage/witness-db",
     "crates/host-bench",
     "crates/mptnew",
+    "bin/verifier-bench",
 ]
 exclude = []
 resolver = "2"
@@ -51,6 +52,7 @@ derive_more = "1.0.0"
 smallvec = "1.13"
 bumpalo = "3.19.0"
 bytes = "1"
+bitcode = { version = "0.6.5", default-features = false, features = ["serde"] }
 
 # workspace
 openvm-rpc-db = { path = "./crates/storage/rpc-db" }
@@ -130,6 +132,7 @@ openvm-build = { git = "https://github.com/openvm-org/openvm.git", branch = "mai
 openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
 openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
 openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
+openvm-continuations = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
 openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
 openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
 openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }

--- a/bin/verifier-bench/.gitignore
+++ b/bin/verifier-bench/.gitignore
@@ -1,0 +1,1 @@
+fixtures/

--- a/bin/verifier-bench/Cargo.toml
+++ b/bin/verifier-bench/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "openvm-reth-verifier-bench"
+edition.workspace = true
+repository.workspace = true
+homepage.workspace = true
+exclude.workspace = true
+version.workspace = true
+
+[dependencies]
+openvm-circuit.workspace = true
+openvm-native-circuit = { workspace = true }
+openvm-sdk = { workspace = true }
+openvm-continuations = { workspace = true }
+openvm-native-recursion = { workspace = true }
+openvm-stark-sdk.workspace = true
+
+bitcode.workspace = true
+
+[lints]
+workspace = true
+
+[features]
+default = ["metrics"]
+metrics = ["openvm-circuit/metrics"]
+tco = ["openvm-sdk/tco"]
+evm-prove = ["openvm-sdk/evm-prove"]
+evm-verify = ["evm-prove", "openvm-sdk/evm-verify"]
+jemalloc = ["openvm-sdk/jemalloc"]
+nightly-features = ["openvm-sdk/nightly-features"]
+

--- a/bin/verifier-bench/Cargo.toml
+++ b/bin/verifier-bench/Cargo.toml
@@ -15,6 +15,7 @@ openvm-native-recursion = { workspace = true }
 openvm-stark-sdk.workspace = true
 
 bitcode.workspace = true
+clap = { version = "4.5.7", features = ["derive", "env"] }
 
 [lints]
 workspace = true
@@ -27,4 +28,3 @@ evm-prove = ["openvm-sdk/evm-prove"]
 evm-verify = ["evm-prove", "openvm-sdk/evm-verify"]
 jemalloc = ["openvm-sdk/jemalloc"]
 nightly-features = ["openvm-sdk/nightly-features"]
-

--- a/bin/verifier-bench/README.md
+++ b/bin/verifier-bench/README.md
@@ -1,0 +1,10 @@
+# Profiling Verifier
+
+##  Generate Fixture
+Use `generate-fixtures` mode in `Reth Benchmark` to generate fixtures.
+
+## Download Fixture
+Run `fixtures.sh` to download fixtures into local.
+
+## Samply Profiling
+Compile binary and run `samply record <binary path>`.

--- a/bin/verifier-bench/fixtures.sh
+++ b/bin/verifier-bench/fixtures.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+BLOCK_NUMBER=${BLOCK_NUMBER:-23100006}
+APP_LOG_BLOWUP=${APP_LOG_BLOWUP:-1}
+LEAF_LOG_BLOWUP=${LEAF_LOG_BLOWUP:-1}
+S3_FOLDER="s3://axiom-public-data-sandbox-us-east-1/benchmark/github/fixtures/reth-app${APP_LOG_BLOWUP}-leaf${LEAF_LOG_BLOWUP}-${BLOCK_NUMBER}"
+
+mkdir -p fixtures
+s5cmd  --no-sign-request cp "${S3_FOLDER}/app_proof.bitcode" fixtures
+s5cmd  --no-sign-request cp "${S3_FOLDER}/leaf_proofs.bitcode" fixtures
+s5cmd  --no-sign-request cp "${S3_FOLDER}/app_pk.bitcode" fixtures
+s5cmd  --no-sign-request cp "${S3_FOLDER}/agg_pk.bitcode" fixtures

--- a/bin/verifier-bench/src/main.rs
+++ b/bin/verifier-bench/src/main.rs
@@ -1,0 +1,113 @@
+use openvm_circuit::arch::{ContinuationVmProof, VirtualMachine};
+use openvm_continuations::verifier::{
+    internal::types::InternalVmVerifierInput, leaf::types::LeafVmVerifierInput,
+};
+use openvm_native_circuit::{NativeCpuBuilder, NATIVE_MAX_TRACE_HEIGHTS};
+use openvm_native_recursion::hints::Hintable;
+use openvm_sdk::config::{DEFAULT_NUM_CHILDREN_INTERNAL, DEFAULT_NUM_CHILDREN_LEAF};
+use openvm_sdk::{
+    config::SdkVmConfig,
+    keygen::{AggProvingKey, AppProvingKey},
+    SC,
+};
+use openvm_stark_sdk::config::baby_bear_poseidon2::BabyBearPoseidon2Engine;
+use openvm_stark_sdk::engine::{StarkEngine, StarkFriEngine};
+use openvm_stark_sdk::openvm_stark_backend::proof::Proof;
+use openvm_stark_sdk::openvm_stark_backend::prover::hal::DeviceDataTransporter;
+
+fn main() {
+    let Fixtures { app_proof, leaf_proofs, app_pk, agg_pk } = read_fixtures();
+    let AggProvingKey { leaf_vm_pk, internal_vm_pk, internal_committed_exe, .. } = agg_pk;
+    {
+        let start = std::time::Instant::now();
+        let engine = BabyBearPoseidon2Engine::new(leaf_vm_pk.fri_params);
+        let d_pk = engine.device().transport_pk_to_device(&leaf_vm_pk.vm_pk);
+        let vm = VirtualMachine::new(engine, NativeCpuBuilder, leaf_vm_pk.vm_config.clone(), d_pk)
+            .unwrap();
+        let leaf_exe = app_pk.leaf_committed_exe.exe.clone();
+        let mut interpreter = vm.preflight_interpreter(&leaf_exe).unwrap();
+        let num_app_proofs = app_proof.per_segment.len();
+        let leaf_inputs =
+            LeafVmVerifierInput::chunk_continuation_vm_proof(&app_proof, DEFAULT_NUM_CHILDREN_LEAF);
+        for (i, leaf_input) in leaf_inputs.into_iter().enumerate() {
+            let start = std::time::Instant::now();
+            let input_stream = leaf_input.write_to_stream();
+            let state = vm.create_initial_state(&leaf_exe, input_stream);
+            let out = vm
+                .execute_preflight(&mut interpreter, state, None, NATIVE_MAX_TRACE_HEIGHTS)
+                .expect("Failed to execute preflight");
+            println!("end pc {}", out.to_state.pc);
+            println!("Time to aggregate app proof chunk {i}, {}s", start.elapsed().as_secs_f64());
+        }
+        println!(
+            "Preflight execution leaf verifier to aggregate {num_app_proofs} app proofs, {}s",
+            start.elapsed().as_secs_f64()
+        );
+    }
+    {
+        let start = std::time::Instant::now();
+        let engine = BabyBearPoseidon2Engine::new(internal_vm_pk.fri_params);
+        let d_pk = engine.device().transport_pk_to_device(&internal_vm_pk.vm_pk);
+        let vm =
+            VirtualMachine::new(engine, NativeCpuBuilder, internal_vm_pk.vm_config.clone(), d_pk)
+                .unwrap();
+        let internal_exe = internal_committed_exe.exe.clone();
+        let mut interpreter = vm.preflight_interpreter(&internal_exe).unwrap();
+        let num_leaf_proofs = leaf_proofs.len();
+        let internal_inputs = InternalVmVerifierInput::chunk_leaf_or_internal_proofs(
+            internal_committed_exe.get_program_commit().into(),
+            &leaf_proofs,
+            DEFAULT_NUM_CHILDREN_INTERNAL,
+        );
+        for (i, internal_proof) in internal_inputs.into_iter().enumerate() {
+            let start = std::time::Instant::now();
+            let input_stream = internal_proof.write();
+            let state = vm.create_initial_state(&internal_exe, input_stream);
+            let out = vm
+                .execute_preflight(&mut interpreter, state, None, NATIVE_MAX_TRACE_HEIGHTS)
+                .expect("Failed to execute preflight");
+            println!("end pc {}", out.to_state.pc);
+            println!("Time to aggregate leaf proof chunk {i}, {}s", start.elapsed().as_secs_f64());
+        }
+        println!(
+            "Preflight execution for internal verifier to aggregate {num_leaf_proofs} leaf proofs, {}s",
+            start.elapsed().as_secs_f64()
+        );
+    }
+}
+
+struct Fixtures {
+    app_proof: ContinuationVmProof<SC>,
+    leaf_proofs: Vec<Proof<SC>>,
+    app_pk: AppProvingKey<SdkVmConfig>,
+    agg_pk: AggProvingKey,
+}
+
+fn read_fixtures() -> Fixtures {
+    let app_proof: ContinuationVmProof<SC> = {
+        let content =
+            std::fs::read(format!("{}/fixtures/app_proof.bitcode", env!("CARGO_MANIFEST_DIR")))
+                .unwrap();
+        bitcode::deserialize(&content).unwrap()
+    };
+    let leaf_proofs: Vec<Proof<SC>> = {
+        let content =
+            std::fs::read(format!("{}/fixtures/leaf_proofs.bitcode", env!("CARGO_MANIFEST_DIR")))
+                .unwrap();
+        bitcode::deserialize(&content).unwrap()
+    };
+    let app_pk: AppProvingKey<SdkVmConfig> = {
+        let content =
+            std::fs::read(format!("{}/fixtures/app_pk.bitcode", env!("CARGO_MANIFEST_DIR")))
+                .unwrap();
+        bitcode::deserialize(&content).unwrap()
+    };
+    let agg_pk: AggProvingKey = {
+        let content =
+            std::fs::read(format!("{}/fixtures/agg_pk.bitcode", env!("CARGO_MANIFEST_DIR")))
+                .unwrap();
+        bitcode::deserialize(&content).unwrap()
+    };
+
+    Fixtures { app_proof, leaf_proofs, app_pk, agg_pk }
+}

--- a/crates/host-bench/Cargo.toml
+++ b/crates/host-bench/Cargo.toml
@@ -15,6 +15,7 @@ dotenv = "0.15.0"
 clap = { version = "4.5.7", features = ["derive", "env"] }
 serde.workspace = true
 bincode = { workspace = true, features = ["std"] }
+bitcode = { version = "0.6.5", default-features = false, features = ["serde"] }
 metrics = "0.23.0"
 hex = "0.4.3"
 serde_json.workspace = true

--- a/crates/host-bench/Cargo.toml
+++ b/crates/host-bench/Cargo.toml
@@ -15,7 +15,7 @@ dotenv = "0.15.0"
 clap = { version = "4.5.7", features = ["derive", "env"] }
 serde.workspace = true
 bincode = { workspace = true, features = ["std"] }
-bitcode = { version = "0.6.5", default-features = false, features = ["serde"] }
+bitcode.workspace = true
 metrics = "0.23.0"
 hex = "0.4.3"
 serde_json.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,5 @@
 [toolchain]
-channel = "1.86.0"
-components = ["clippy", "rustfmt", "rust-src"]
-profile = "minimal"
+#channel = "1.86.0"
+# To use the "tco" feature, switch to Rust nightly:
+channel = "nightly-2025-08-19"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
- Add a mode into reth-benchmark to generate fixtures.
- Add a binary for leaf/internal.0 profiling.