### PR TITLE
chore: lock openvm dep to rc.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4391,7 +4391,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "bytemuck",
  "num-bigint 0.4.6",
@@ -4404,7 +4404,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4436,7 +4436,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4446,7 +4446,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint 0.4.6",
@@ -4462,7 +4462,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "num-bigint 0.4.6",
  "num-prime",
@@ -4474,7 +4474,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -4488,7 +4488,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-prove"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "clap",
  "derive_more 1.0.0",
@@ -4515,7 +4515,7 @@ dependencies = [
 [[package]]
 name = "openvm-benchmarks-utils"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -4530,7 +4530,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4556,7 +4556,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -4565,7 +4565,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -4580,7 +4580,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cargo_metadata",
  "eyre",
@@ -4592,7 +4592,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "backtrace",
  "cfg-if",
@@ -4631,7 +4631,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -4642,7 +4642,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -4660,7 +4660,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -4697,7 +4697,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "derivative",
  "openvm-circuit",
@@ -4766,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4776,7 +4776,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4808,7 +4808,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -4827,7 +4827,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -4837,7 +4837,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -4882,7 +4882,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -4899,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -4908,7 +4908,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -4936,7 +4936,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-platform",
 ]
@@ -4944,7 +4944,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -4958,7 +4958,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "syn 2.0.103",
 ]
@@ -4966,7 +4966,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cuda-runtime-sys",
  "itertools 0.14.0",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5069,7 +5069,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "backtrace",
  "itertools 0.14.0",
@@ -5093,7 +5093,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-compiler-derive"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -5102,7 +5102,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-recursion"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "itertools 0.14.0",
@@ -5130,7 +5130,7 @@ dependencies = [
 [[package]]
 name = "openvm-native-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-instructions",
  "openvm-transpiler",
@@ -5140,7 +5140,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5171,7 +5171,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "halo2curves-axiom",
  "hex-literal 0.4.1",
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -5205,7 +5205,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -5215,7 +5215,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -5323,7 +5323,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -5340,7 +5340,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5367,7 +5367,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -5377,7 +5377,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5393,7 +5393,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "alloy-sol-types 0.8.25",
  "bitcode",
@@ -5452,7 +5452,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -5489,7 +5489,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-platform",
 ]
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -5576,7 +5576,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "1.4.0-rc.7"
-source = "git+https://github.com/openvm-org/openvm.git?branch=main#530060b4e70f7df6ace6de992efda133122b567a"
+source = "git+https://github.com/openvm-org/openvm.git?tag=v1.4.0-rc.7#530060b4e70f7df6ace6de992efda133122b567a"
 dependencies = [
  "elf",
  "eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,26 +120,26 @@ openvm-cuda-backend = { git = "https://github.com/openvm-org/stark-backend.git",
 # Note: the openvm-sdk commit does not need to be exactly the same as the `openvm` commit used in the guest program: as long as
 # the openvm-sdk commit doesn't change any guest libraries, they are compatible
 # This allows us to not update revm and openvm-kzg each time we change openvm-sdk
-openvm-build = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-native-circuit = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
-openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", branch = "main", default-features = false }
+openvm-build = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-benchmarks-prove = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-keccak256-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-keccak256-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-rv32im-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-rv32im-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-bigint-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-bigint-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-algebra-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-algebra-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-ecc-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-ecc-transpiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-pairing-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-sdk = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-native-circuit = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-native-compiler = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
+openvm-native-recursion = { git = "https://github.com/openvm-org/openvm.git", tag = "v1.4.0-rc.7", default-features = false }
 
 [workspace.lints]
 rust.missing_debug_implementations = "warn"


### PR DESCRIPTION
Using `branch = main` causes issues when importing the crate as a dependency in other repos. 

The current issue I run into is everything in this repo expects `openvm` v1.4.0-rc.7 but when I try to pull the `openvm-reth-benchmark` crate, its deps pull `openvm` branch `main` which is not the same as the tagged commit of v1.4.0-rc.7.