### PR TITLE
feat: make openvm extensions optional in guest

### DIFF
--- a/bin/stateless-guest/Cargo.toml
+++ b/bin/stateless-guest/Cargo.toml
@@ -7,24 +7,29 @@ edition = "2021"
 
 [dependencies]
 # workspace
-openvm-stateless-executor = { path = "../../crates/stateless-executor", features = ["openvm"] }
+openvm-stateless-executor = { path = "../../crates/stateless-executor", default-features = false }
 
 # openvm
 openvm = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.0.0-rc.1", features = [
     "std",
 ] }
-openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.0.0-rc.1" }
-openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.0.0-rc.1" }
+openvm-algebra-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.0.0-rc.1", optional = true }
+openvm-ecc-guest = { git = "https://github.com/openvm-org/openvm.git", branch = "develop-v2.0.0-rc.1", optional = true }
 
 # Enable std feature for host builds (provides critical-section implementation)
 [target.'cfg(not(target_os = "zkvm"))'.dependencies]
-openvm-stateless-executor = { path = "../../crates/stateless-executor", features = ["openvm", "std"] }
+openvm-stateless-executor = { path = "../../crates/stateless-executor", default-features = false, features = ["std"] }
 
 [package.metadata.cargo-machete]
 ignored = ["openvm-algebra-guest", "openvm-ecc-guest"]
 
 [features]
-default = []
+default = ["extensions"]
+extensions = [
+    "openvm-stateless-executor/openvm",
+    "dep:openvm-algebra-guest",
+    "dep:openvm-ecc-guest",
+]
 heap-embedded-alloc = ["openvm/heap-embedded-alloc"]
 
 [profile.release]

--- a/bin/stateless-guest/src/main.rs
+++ b/bin/stateless-guest/src/main.rs
@@ -1,6 +1,7 @@
 use openvm::io::{read, reveal_bytes32};
 use openvm_stateless_executor::{io::StatelessExecutorInput, ChainVariant, StatelessExecutor};
 
+#[cfg(all(target_os = "zkvm", feature = "extensions"))]
 openvm::init!();
 
 pub fn main() {


### PR DESCRIPTION
- move openvm precompiles/extensions in guest behind a `extensions` feature

resolves int-6793