### PR TITLE
fix(v2): use `cargo-openvm` from v2 branch

### DIFF
--- a/.cargo/config.local.toml
+++ b/.cargo/config.local.toml
@@ -5,66 +5,73 @@ git-fetch-with-cli = true
 [patch."https://github.com/openvm-org/stark-backend.git"]
 openvm-stark-backend = { path = "../openvm-org/stark-backend/crates/stark-backend" }
 openvm-stark-sdk = { path = "../openvm-org/stark-backend/crates/stark-sdk" }
+openvm-codec-derive = { path = "../openvm-org/stark-backend/crates/codec-derive" }
+openvm-cpu-backend = { path = "../openvm-org/stark-backend/crates/cpu-backend" }
 openvm-cuda-builder = { path = "../openvm-org/stark-backend/crates/cuda-builder" }
 openvm-cuda-common = { path = "../openvm-org/stark-backend/crates/cuda-common" }
-openvm-cuda-backend = { path = "../openvm-org/stark-backend/crates/cuda-backend " }
+openvm-cuda-backend = { path = "../openvm-org/stark-backend/crates/cuda-backend" }
 
 [patch."https://github.com/openvm-org/openvm.git"]
-openvm-benchmarks-prove = { path = "../openvm-org/openvm/benchmarks/prove" }
-# OpenVM
-openvm-sdk = { path = "../openvm-org/openvm/crates/sdk" }
-cargo-openvm = { path = "../openvm-org/openvm/crates/cli" }
-openvm-mod-circuit-builder = { path = "../openvm-org/openvm/crates/circuits/mod-builder" }
-openvm-poseidon2-air = { path = "../openvm-org/openvm/crates/circuits/poseidon2-air" }
+# OpenVM core
+openvm = { path = "../openvm-org/openvm/crates/toolchain/openvm" }
+# TODO: add back
+# openvm-benchmarks-prove = { path = "../openvm-org/openvm/benchmarks/prove" }
+openvm-build = { path = "../openvm-org/openvm/crates/toolchain/build" }
+openvm-circuit = { path = "../openvm-org/openvm/crates/vm" }
+openvm-circuit-derive = { path = "../openvm-org/openvm/crates/vm/derive" }
 openvm-circuit-primitives = { path = "../openvm-org/openvm/crates/circuits/primitives" }
 openvm-circuit-primitives-derive = { path = "../openvm-org/openvm/crates/circuits/primitives/derive" }
-openvm = { path = "../openvm-org/openvm/crates/toolchain/openvm" }
-openvm-build = { path = "../openvm-org/openvm/crates/toolchain/build" }
+openvm-continuations = { path = "../openvm-org/openvm/crates/continuations" }
+openvm-custom-insn = { path = "../openvm-org/openvm/crates/toolchain/custom_insn" }
 openvm-instructions = { path = "../openvm-org/openvm/crates/toolchain/instructions" }
 openvm-instructions-derive = { path = "../openvm-org/openvm/crates/toolchain/instructions/derive" }
 openvm-macros-common = { path = "../openvm-org/openvm/crates/toolchain/macros" }
+openvm-mod-circuit-builder = { path = "../openvm-org/openvm/crates/circuits/mod-builder" }
 openvm-platform = { path = "../openvm-org/openvm/crates/toolchain/platform" }
+openvm-poseidon2-air = { path = "../openvm-org/openvm/crates/circuits/poseidon2-air" }
+openvm-recursion-circuit = { path = "../openvm-org/openvm/crates/recursion" }
+openvm-recursion-circuit-derive = { path = "../openvm-org/openvm/crates/recursion/derive" }
+openvm-sdk = { path = "../openvm-org/openvm/crates/sdk" }
+openvm-sdk-config = { path = "../openvm-org/openvm/crates/sdk-config" }
 openvm-transpiler = { path = "../openvm-org/openvm/crates/toolchain/transpiler" }
-openvm-circuit = { path = "../openvm-org/openvm/crates/vm" }
-openvm-circuit-derive = { path = "../openvm-org/openvm/crates/vm/derive" }
+openvm-verify-stark-host = { path = "../openvm-org/openvm/crates/verify" }
 
 # Extensions
 openvm-algebra-circuit = { path = "../openvm-org/openvm/extensions/algebra/circuit" }
-openvm-algebra-transpiler = { path = "../openvm-org/openvm/extensions/algebra/transpiler" }
+openvm-algebra-complex-macros = { path = "../openvm-org/openvm/extensions/algebra/complex-macros" }
 openvm-algebra-guest = { path = "../openvm-org/openvm/extensions/algebra/guest" }
 openvm-algebra-moduli-macros = { path = "../openvm-org/openvm/extensions/algebra/moduli-macros" }
-openvm-algebra-complex-macros = { path = "../openvm-org/openvm/extensions/algebra/complex-macros" }
+openvm-algebra-transpiler = { path = "../openvm-org/openvm/extensions/algebra/transpiler" }
 openvm-bigint-circuit = { path = "../openvm-org/openvm/extensions/bigint/circuit" }
-openvm-bigint-transpiler = { path = "../openvm-org/openvm/extensions/bigint/transpiler" }
 openvm-bigint-guest = { path = "../openvm-org/openvm/extensions/bigint/guest" }
+openvm-bigint-transpiler = { path = "../openvm-org/openvm/extensions/bigint/transpiler" }
+openvm-deferral-circuit = { path = "../openvm-org/openvm/extensions/deferral/circuit" }
+openvm-deferral-guest = { path = "../openvm-org/openvm/extensions/deferral/guest" }
+openvm-deferral-transpiler = { path = "../openvm-org/openvm/extensions/deferral/transpiler" }
 openvm-ecc-circuit = { path = "../openvm-org/openvm/extensions/ecc/circuit" }
-openvm-ecc-transpiler = { path = "../openvm-org/openvm/extensions/ecc/transpiler" }
 openvm-ecc-guest = { path = "../openvm-org/openvm/extensions/ecc/guest" }
 openvm-ecc-sw-macros = { path = "../openvm-org/openvm/extensions/ecc/sw-macros" }
+openvm-ecc-transpiler = { path = "../openvm-org/openvm/extensions/ecc/transpiler" }
 openvm-keccak256-circuit = { path = "../openvm-org/openvm/extensions/keccak256/circuit" }
-openvm-keccak256-transpiler = { path = "../openvm-org/openvm/extensions/keccak256/transpiler" }
 openvm-keccak256-guest = { path = "../openvm-org/openvm/extensions/keccak256/guest" }
-openvm-sha256-circuit = { path = "../openvm-org/openvm/extensions/sha256/circuit" }
-openvm-sha256-transpiler = { path = "../openvm-org/openvm/extensions/sha256/transpiler" }
-openvm-sha256-guest = { path = "../openvm-org/openvm/extensions/sha256/guest" }
-openvm-native-circuit = { path = "../openvm-org/openvm/extensions/native/circuit" }
-openvm-native-compiler = { path = "../openvm-org/openvm/extensions/native/compiler" }
-openvm-native-compiler-derive = { path = "../openvm-org/openvm/extensions/native/compiler/derive" }
-openvm-native-recursion = { path = "../openvm-org/openvm/extensions/native/recursion" }
+openvm-keccak256-transpiler = { path = "../openvm-org/openvm/extensions/keccak256/transpiler" }
 openvm-pairing-circuit = { path = "../openvm-org/openvm/extensions/pairing/circuit" }
-openvm-pairing-transpiler = { path = "../openvm-org/openvm/extensions/pairing/transpiler" }
 openvm-pairing-guest = { path = "../openvm-org/openvm/extensions/pairing/guest" }
+openvm-pairing-transpiler = { path = "../openvm-org/openvm/extensions/pairing/transpiler" }
 openvm-rv32-adapters = { path = "../openvm-org/openvm/extensions/rv32-adapters" }
 openvm-rv32im-circuit = { path = "../openvm-org/openvm/extensions/rv32im/circuit" }
-openvm-rv32im-transpiler = { path = "../openvm-org/openvm/extensions/rv32im/transpiler" }
 openvm-rv32im-guest = { path = "../openvm-org/openvm/extensions/rv32im/guest" }
+openvm-rv32im-transpiler = { path = "../openvm-org/openvm/extensions/rv32im/transpiler" }
+openvm-sha256-circuit = { path = "../openvm-org/openvm/extensions/sha256/circuit" }
+openvm-sha256-guest = { path = "../openvm-org/openvm/extensions/sha256/guest" }
+openvm-sha256-transpiler = { path = "../openvm-org/openvm/extensions/sha256/transpiler" }
 
-# Guest Libs
+# Guest libs
 k256 = { path = "../openvm-org/openvm/guest-libs/k256" }
 p256 = { path = "../openvm-org/openvm/guest-libs/p256" }
 openvm-keccak256 = { path = "../openvm-org/openvm/guest-libs/keccak256" }
-openvm-sha2 = { path = "../openvm-org/openvm/guest-libs/sha2" }
 openvm-pairing = { path = "../openvm-org/openvm/guest-libs/pairing" }
+openvm-sha2 = { path = "../openvm-org/openvm/guest-libs/sha2" }
 
 # NOTE: do not patch k256 for host as it causes some issues
 # [patch.crates-io]

--- a/.cargo/config.template.toml
+++ b/.cargo/config.template.toml
@@ -4,64 +4,74 @@ git-fetch-with-cli = true
 [patch."https://github.com/openvm-org/stark-backend.git"]
 openvm-stark-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
 openvm-stark-sdk = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
+openvm-codec-derive = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
+openvm-cpu-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
 openvm-cuda-builder = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
 openvm-cuda-common = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
 openvm-cuda-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", rev = "$STARK_BACKEND_REV" }
 
 [patch."https://github.com/openvm-org/openvm.git"]
-openvm-benchmarks-prove = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-sdk = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-cargo-openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-mod-circuit-builder = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-poseidon2-air = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+# OpenVM core
+openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+# TODO: add back
+# openvm-benchmarks-prove = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-build = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-circuit-primitives = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-circuit-primitives-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-build = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-continuations = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-custom-insn = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-instructions = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-instructions-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-macros-common = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-mod-circuit-builder = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-platform = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-poseidon2-air = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-recursion-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-recursion-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-sdk = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-sdk-config = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-verify-stark-host = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 
+# Extensions
 openvm-algebra-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-algebra-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-algebra-complex-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-algebra-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-algebra-moduli-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-algebra-complex-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-algebra-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-bigint-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-bigint-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-bigint-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-bigint-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-deferral-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-deferral-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-deferral-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-ecc-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-ecc-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-ecc-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-ecc-sw-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-ecc-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-keccak256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-keccak256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-keccak256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-native-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-native-compiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-native-compiler-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-native-recursion = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-keccak256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-pairing-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-pairing-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-pairing-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-pairing-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-rv32-adapters = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-rv32im-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-rv32im-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-rv32im-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-rv32im-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-sha256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-sha256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-sha256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 
-# Guest Libs
+# Guest libs
 k256 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 p256 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-keccak256 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
-openvm-sha2 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 openvm-pairing = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
+openvm-sha2 = { git = "ssh://git@github.com/openvm-org/openvm.git", rev = "$OPENVM_REV" }
 
-# OpenVM
-# Extensions
 # [patch.crates-io]
 # revm = { path = "../revm/crates/revm" }
 # revm-primitives = { path = "../revm/crates/primitives" }

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,60 +7,70 @@
 # # [patch."https://github.com/openvm-org/stark-backend.git"]
 # # openvm-stark-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
 # # openvm-stark-sdk = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
+# # openvm-codec-derive = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
+# # openvm-cpu-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
+# # openvm-cuda-builder = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
+# # openvm-cuda-common = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
+# # openvm-cuda-backend = { git = "ssh://git@github.com/openvm-org/stark-backend.git", tag = "v1.2.0" }
 
 # [patch."https://github.com/openvm-org/openvm.git"]
-# openvm-benchmarks-prove = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# # OpenVM
-# openvm-sdk = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# cargo-openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-mod-circuit-builder = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-poseidon2-air = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# # OpenVM core
+# openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# # TODO: add back
+# # openvm-benchmarks-prove = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-build = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-circuit-primitives = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-circuit-primitives-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-build = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-continuations = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-custom-insn = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-instructions = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-instructions-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-macros-common = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-mod-circuit-builder = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-platform = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-poseidon2-air = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-recursion-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-recursion-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-sdk = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-sdk-config = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-circuit-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-
+# openvm-verify-stark-host = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+#
 # # Extensions
 # openvm-algebra-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-algebra-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-algebra-complex-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-algebra-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-algebra-moduli-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-algebra-complex-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-algebra-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-bigint-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-bigint-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-bigint-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-bigint-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-deferral-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-deferral-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-deferral-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-ecc-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-ecc-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-ecc-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-ecc-sw-macros = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-ecc-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-keccak256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-keccak256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-keccak256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-sha256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-sha256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-sha256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-native-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-native-compiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-native-compiler-derive = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-native-recursion = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-keccak256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-pairing-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-pairing-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-pairing-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-pairing-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-rv32-adapters = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-rv32im-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-rv32im-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-rv32im-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-
-# # Guest Libs
+# openvm-rv32im-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-sha256-circuit = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-sha256-guest = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-sha256-transpiler = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+#
+# # Guest libs
 # k256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # p256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-keccak256 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
-# openvm-sha2 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
 # openvm-pairing = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }
+# openvm-sha2 = { git = "ssh://git@github.com/openvm-org/openvm.git", branch = "main" }

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -39,6 +39,8 @@ on:
         required: false
         description: Running mode
         options:
+          - execute
+          - execute-metered
           - prove-app
           - prove-stark
           # - prove-evm
@@ -120,7 +122,7 @@ on:
       mode:
         type: string
         required: false
-        description: Running mode, one of {prove-app, prove-stark}
+        description: Running mode, one of {execute, execute-metered, prove-app, prove-stark}
         default: prove-stark
       profiling:
         type: string
@@ -248,8 +250,6 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-      - name: Checkout openvm-eth (for guest program build)
-        run: git clone --depth=1 --branch="develop-new-hintstore" https://github.com/axiom-crypto/openvm-eth.git openvm-eth-v1
       - name: Checkout openvm (for scripts)
         run: git clone --depth=1 --branch="develop-v2.0.0-beta" https://github.com/openvm-org/openvm.git
       - name: Install openvm-prof
@@ -314,29 +314,14 @@ jobs:
         run: |
           arch=$(uname -m)
           # Use inputs.tag if defined, otherwise use current commit SHA
-          if [[ -n "${{ inputs.tag }}" ]]; then
-            GUEST_TAG="${{ inputs.tag }}"
-            HOST_TAG="${{ inputs.tag }}"
-          else
-            # host depends on GPU repo
-            CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -d' ' -f1 | cut -c1-8)
-            HOST_TAG="$(git rev-parse HEAD)-${CARGO_LOCK_HASH}"
-
-            # guest only depends on guest program code and openvm guest dependencies
-            cd openvm-eth-v1/bin/stateless-guest
-            CARGO_LOCK_HASH=$(sha256sum Cargo.lock | cut -d' ' -f1 | cut -c1-8)
-            # openvm-eth's commit SHA and guest program's Cargo.lock hash
-            GUEST_TAG="$(git rev-parse HEAD)-${CARGO_LOCK_HASH}"
-          fi
-
+          TAG="${{ inputs.tag || env.current_sha }}"
           GUEST_PROFILE=${{ steps.set-build-profiles.outputs.guest_profile }}
-          echo "elf_cache_key=elf-${GUEST_TAG}-${arch}-${GUEST_PROFILE}" >> $GITHUB_OUTPUT
-
+          echo "elf_cache_key=elf-${TAG}-${arch}-${GUEST_PROFILE}" >> $GITHUB_OUTPUT
           RUSTFLAGS_HASH=$(echo "${RUSTFLAGS}" | sha256sum | cut -d' ' -f1 | head -c8)
           JEMALLOC_CONF_HASH=$(echo "${JEMALLOC_SYS_WITH_MALLOC_CONF}" | sha256sum | cut -d' ' -f1 | head -c8)
           FEATURES_HASH=$(echo "${FEATURES}" | sha256sum | cut -d' ' -f1 | head -c8)
           HOST_PROFILE=${{ steps.set-build-profiles.outputs.host_profile }}
-          echo "host_cache_key=host-${HOST_TAG}-${arch}-${HOST_PROFILE}-${RUSTFLAGS_HASH}-${JEMALLOC_CONF_HASH}-${FEATURES_HASH}" >> $GITHUB_OUTPUT
+          echo "host_cache_key=host-${TAG}-${arch}-${HOST_PROFILE}-${RUSTFLAGS_HASH}-${JEMALLOC_CONF_HASH}-${FEATURES_HASH}" >> $GITHUB_OUTPUT
 
       - name: Restore Guest ELF from cache
         id: cache-guest-elf-restore
@@ -348,8 +333,7 @@ jobs:
       - name: Install cargo-openvm
         if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true' && steps.cache-cargo-openvm-restore.outputs.cache-hit != 'true'
         run: |
-          # Build using v1 cargo-openvm until v2 CLI is stable
-          cargo install --git https://github.com/openvm-org/openvm.git --branch "main" --locked --force cargo-openvm
+          cargo install --git https://github.com/openvm-org/openvm.git --branch "develop-v2.0.0-beta" --locked --force cargo-openvm
 
       - name: Save cargo-openvm to cache
         if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true' && steps.cache-cargo-openvm-restore.outputs.cache-hit != 'true'
@@ -359,14 +343,12 @@ jobs:
           key: ${{ steps.cache-cargo-openvm-restore.outputs.cache-primary-key }}
       - name: Build Guest ELF
         if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true'
+        working-directory: bin/stateless-guest
         run: |
-          WORK_DIR=$(pwd)
-          mkdir -p bin/reth-benchmark/elf
-          # TODO: This is openvm-eth on develop-new-hintstore branch. Revert at CLI enabled in v2
-          cd openvm-eth-v1/bin/stateless-guest
           GUEST_PROFILE=${{ steps.set-build-profiles.outputs.guest_profile }}
           RUSTFLAGS="" cargo openvm build --no-transpile --profile=$GUEST_PROFILE
-          cp target/riscv32im-risc0-zkvm-elf/$GUEST_PROFILE/openvm-stateless-guest $WORK_DIR/bin/reth-benchmark/elf/
+          mkdir -p ../reth-benchmark/elf
+          cp target/riscv32im-risc0-zkvm-elf/$GUEST_PROFILE/openvm-stateless-guest ../reth-benchmark/elf/
 
       - name: Save Guest ELF to cache
         if: steps.cache-guest-elf-restore.outputs.cache-hit != 'true'
@@ -481,7 +463,8 @@ jobs:
             # Start GPU memory monitoring
             start_gpu_monitor "$GPU_LOG_FILE" 5
 
-            ./ci/monitor_memory.sh ./run_benchmark.sh
+            set -o pipefail
+            ./ci/monitor_memory.sh ./run_benchmark.sh 2>&1 | tee benchmark_output.log
 
             # Finalize GPU monitoring and capture peak
             finalize_gpu_monitor
@@ -489,6 +472,11 @@ jobs:
             echo "GPU_LOG_FILE=${GPU_LOG_FILE}" >> $GITHUB_ENV
 
             echo "MEM_USAGE_PATH=memory_usage.png" >> $GITHUB_ENV
+          fi
+
+          # Extract benchmark outputs
+          if grep -q "BENCH_NUM_SEGMENTS=" benchmark_output.log 2>/dev/null; then
+            grep "BENCH_NUM_SEGMENTS=" benchmark_output.log >> $GITHUB_ENV
           fi
 
       - name: Report GPU peak memory
@@ -499,6 +487,11 @@ jobs:
           echo "### GPU Memory" >> $GITHUB_STEP_SUMMARY
           echo "Peak GPU memory usage: **${GPU_PEAK_MEMORY_MIB} MiB**" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ -n "${BENCH_NUM_SEGMENTS}" ]]; then
+            echo "### Segments" >> $GITHUB_STEP_SUMMARY
+            echo "Number of segments: **${BENCH_NUM_SEGMENTS}**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Upload memory usage graph
         if: ${{ (inputs.profiling || github.event.inputs.profiling) == 'none' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5101,7 +5101,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6263,7 +6263,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "bytemuck",
  "num-bigint",
@@ -6276,7 +6276,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6311,7 +6311,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6321,7 +6321,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "halo2curves-axiom 0.7.2",
  "num-bigint",
@@ -6337,7 +6337,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -6349,7 +6349,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -6363,7 +6363,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6390,7 +6390,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -6399,7 +6399,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -6414,7 +6414,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cargo_metadata 0.18.1",
  "eyre",
@@ -6436,7 +6436,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "abi_stable",
  "backtrace",
@@ -6481,7 +6481,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6492,7 +6492,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -6511,7 +6511,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "itertools 0.14.0",
  "quote",
@@ -6532,7 +6532,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6646,7 +6646,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cfg-if",
  "dashmap 6.1.0",
@@ -6680,7 +6680,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -6689,7 +6689,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "eyre",
  "openvm-deferral-guest",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6739,7 +6739,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6758,7 +6758,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6768,7 +6768,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -6782,7 +6782,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -6799,7 +6799,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -6808,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-keccak256-guest",
  "tiny-keccak",
@@ -6817,7 +6817,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6846,7 +6846,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-platform",
 ]
@@ -6854,7 +6854,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -6884,7 +6884,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "syn 2.0.102",
 ]
@@ -6892,7 +6892,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cuda-runtime-sys",
  "itertools 0.14.0",
@@ -6954,7 +6954,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "group 0.13.0",
  "hex-literal",
@@ -6977,7 +6977,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7009,7 +7009,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "blstrs",
  "halo2curves-axiom 0.7.2",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -7043,7 +7043,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -7053,7 +7053,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -7070,7 +7070,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "derive-new 0.6.0",
  "eyre",
@@ -7099,7 +7099,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7203,7 +7203,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -7220,7 +7220,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7248,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -7258,7 +7258,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7274,7 +7274,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "bitcode",
  "bon",
@@ -7311,7 +7311,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk-config"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "bon",
  "cfg-if",
@@ -7346,7 +7346,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-sha256-guest",
  "sha2",
@@ -7355,7 +7355,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-air"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-circuit-primitives",
  "openvm-stark-backend",
@@ -7366,7 +7366,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-circuit"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7393,7 +7393,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-platform",
 ]
@@ -7401,7 +7401,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7530,7 +7530,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "elf",
  "eyre",
@@ -7545,7 +7545,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-host"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "bitcode",
  "eyre",
@@ -7589,7 +7589,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -30,7 +30,9 @@ use openvm_stark_sdk::{
         p3_field::PrimeCharacteristicRing,
     },
 };
-use openvm_stateless_executor::{io::StatelessExecutorInput, CHAIN_ID_ETH_MAINNET};
+use openvm_stateless_executor::{
+    io::StatelessExecutorInput, ChainVariant, StatelessExecutor, CHAIN_ID_ETH_MAINNET,
+};
 use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE, FromElf};
 use openvm_verify_stark_host::{
     verify_vm_stark_proof_decoded,
@@ -321,6 +323,42 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         }
     };
 
+    // MakeInput: encode stateless_input as JSON and write to disk.
+    if matches!(args.mode, BenchMode::MakeInput) {
+        let words = openvm::serde::to_vec(&stateless_input)?;
+        let bytes: Vec<u8> = words.into_iter().flat_map(|w: u32| w.to_le_bytes()).collect();
+        let hex = format!("0x01{}", hex::encode(&bytes));
+        let json = serde_json::json!({ "input": [hex] });
+
+        if let Some(ref path) = args.generated_input_path {
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            fs::write(path, serde_json::to_string(&json)?)?;
+            info!("Wrote input JSON to {}", path.display());
+        } else {
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        return Ok(());
+    }
+
+    // Host execution: run the stateless executor natively, no VM.
+    if matches!(args.mode, BenchMode::ExecuteHost) {
+        let program_name = format!("reth.{}.block_{}", args.mode, block_number);
+        let executor = StatelessExecutor;
+        let start = Instant::now();
+        let header = info_span!("host.execute", group = program_name).in_scope(|| {
+            info_span!("client.execute")
+                .in_scope(|| executor.execute(ChainVariant::Mainnet, stateless_input))
+        })?;
+        let elapsed = start.elapsed();
+        let block_hash = header.hash_slow();
+        info!("Host execution: {:.6}s, block hash: {}", elapsed.as_secs_f64(), block_hash,);
+        println!("BENCH_HOST_NS={}", elapsed.as_nanos());
+        println!("BENCH_BLOCK_HASH={block_hash}");
+        return Ok(());
+    }
+
     let encoded_stateless_input: Vec<F> = {
         let words = openvm::serde::to_vec(&stateless_input)?;
         words.into_iter().flat_map(|w| w.to_le_bytes()).map(F::from_u8).collect()
@@ -331,10 +369,27 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     run_with_metric_collection("OUTPUT_PATH", move || {
         info_span!("reth-block", block_number = block_number).in_scope(|| -> eyre::Result<()> {
             match args.mode {
+                BenchMode::Execute => {
+                    let public_values = info_span!("sdk.execute", group = program_name)
+                        .in_scope(|| sdk.execute(exe, stdin))?;
+                    let block_hash = hex::encode(&public_values);
+                    info!("Execute completed, block hash: {}", block_hash);
+                    println!("BENCH_BLOCK_HASH={block_hash}");
+                }
+                BenchMode::ExecuteMetered => {
+                    let (public_values, segments) =
+                        info_span!("sdk.execute_metered", group = program_name)
+                            .in_scope(|| sdk.execute_metered(exe, stdin))?;
+                    let block_hash = hex::encode(&public_values);
+                    info!("Execute metered completed, block hash: {}", block_hash);
+                    println!("BENCH_BLOCK_HASH={block_hash}");
+                    println!("BENCH_NUM_SEGMENTS={}", segments.len());
+                }
                 BenchMode::ProveApp => {
                     let mut prover = sdk.app_prover(exe)?;
                     prover.set_program_name(program_name);
                     let app_proof = prover.prove(stdin)?;
+                    println!("BENCH_NUM_SEGMENTS={}", app_proof.per_segment.len());
                     let (_, app_vk) = sdk.app_keygen();
                     verify_segments(&prover.vm().engine, &app_vk.vk, &app_proof.per_segment)?;
                 }
@@ -377,14 +432,14 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                     info!("Saving agg proving key to: {}", agg_pk_path.display());
                     write_object_to_file(&agg_pk_path, &agg_pk)?;
 
-                    info!("✅ Keygen completed successfully!");
+                    info!("Keygen completed successfully!");
                     info!("  App PK: {}", app_pk_path.display());
                     info!("  App VK: {}", app_vk_path.display());
                     info!("  Agg PK: {}", agg_pk_path.display());
                 }
                 _ => {
-                    // This case is handled earlier and should not reach here
-                    todo!();
+                    // MakeInput, ExecuteHost, GenerateVmVkey, DumpAirStats handled earlier
+                    unreachable!();
                 }
             }
 

--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2708,7 +2708,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.17",
@@ -2723,7 +2723,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2733,7 +2733,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint",
@@ -2749,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2781,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2810,7 +2810,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-keccak256-guest",
  "tiny-keccak",
@@ -2819,7 +2819,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-platform",
 ]
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "syn 2.0.114",
 ]
@@ -2866,7 +2866,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "group",
  "hex-literal",
@@ -2889,7 +2889,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "hex-literal",
  "itertools 0.14.0",
@@ -2908,7 +2908,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -2938,7 +2938,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -2948,7 +2948,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-sha256-guest",
  "sha2",
@@ -2957,7 +2957,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha256-guest"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "openvm-platform",
 ]
@@ -3015,7 +3015,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#50e7f470179cc7de72a3c612ece178e8fde8b219"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-beta#717654b3bb8810146c2af6abe43f10abf1ffec59"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/run.sh
+++ b/run.sh
@@ -29,11 +29,14 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 WORKDIR=$REPO_ROOT
 
-# TODO[jpw]: currently this needs to be built from openvm-eth:develop-new-hintstore because CLI is disabled on openvm v2 branch
-DEST="$REPO_ROOT/bin/reth-benchmark/elf/openvm-stateless-guest"
-if [ ! -f "$DEST" ]; then
-    echo "Guest ELF not found: $DEST"
-    exit 1
+cd "$REPO_ROOT/bin/stateless-guest"
+cargo openvm build
+mkdir -p ../reth-benchmark/elf
+SRC="target/riscv32im-risc0-zkvm-elf/release/openvm-stateless-guest"
+DEST="../reth-benchmark/elf/openvm-stateless-guest"
+
+if [ ! -f "$DEST" ] || ! cmp -s "$SRC" "$DEST"; then
+    cp "$SRC" "$DEST"
 fi
 
 cd $WORKDIR


### PR DESCRIPTION
- also adds back `MakeInput`, `ExecuteHost`, `Execute` and `ExecuteMetered` modes
- updates lock files