### PR TITLE
fix: deterministic witness ordering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7688,6 +7688,7 @@ version = "0.4.0"
 dependencies = [
  "alloy-rlp",
  "alloy-rpc-types-debug",
+ "itertools 0.14.0",
  "metrics 0.24.3",
  "openvm-mpt",
  "openvm-stateless-executor",

--- a/crates/rpc-proxy/src/witness.rs
+++ b/crates/rpc-proxy/src/witness.rs
@@ -12,6 +12,7 @@ use alloy::{
 };
 use alloy_rpc_types_debug::ExecutionWitness;
 use eyre::{Context, ContextCompat, Result};
+use itertools::Itertools;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_primitives_traits::{Block, BlockBody, NodePrimitives};
 use std::collections::HashSet;
@@ -118,10 +119,15 @@ where
 
     debug!("Preflight check completed successfully");
 
+    // Sort for deterministic witness ordering.
     Ok(ExecutionWitness {
-        state: state.into_iter().collect(),
-        codes: db.contracts().values().cloned().collect(),
-        keys: storage_tries.keys().map(|addr| Bytes::copy_from_slice(addr.as_slice())).collect(),
+        state: state.into_iter().sorted().collect(),
+        codes: db.contracts().values().cloned().sorted().collect(),
+        keys: storage_tries
+            .keys()
+            .map(|addr| Bytes::copy_from_slice(addr.as_slice()))
+            .sorted()
+            .collect(),
         headers,
     })
 }

--- a/crates/stateless-witness/Cargo.toml
+++ b/crates/stateless-witness/Cargo.toml
@@ -25,6 +25,7 @@ reth-revm = { workspace = true }
 alloy-rpc-types-debug.workspace = true
 alloy-rlp.workspace = true
 
+itertools.workspace = true
 tracing.workspace = true
 metrics.workspace = true
 thiserror.workspace = true

--- a/crates/stateless-witness/src/lib.rs
+++ b/crates/stateless-witness/src/lib.rs
@@ -3,6 +3,7 @@
 //! use either within the Reth SDK, as part of a Reth ExEx, or by Reth RPC clients.
 use alloy_rlp::Encodable;
 use alloy_rpc_types_debug::ExecutionWitness;
+use itertools::Itertools;
 use openvm_mpt::{resolver::MptResolver, EthereumState};
 use openvm_stateless_executor::io::StatelessExecutorInput;
 use reth_ethereum::{
@@ -145,8 +146,13 @@ where
     // Ancestor headers start from most recent
     ancestor_headers.reverse();
 
-    let execution_witness =
-        ExecutionWitness { state: reth_state, codes, keys, headers: serialized_headers };
+    // Sort for deterministic witness ordering.
+    let execution_witness = ExecutionWitness {
+        state: reth_state.into_iter().sorted().collect(),
+        codes: codes.into_iter().sorted().collect(),
+        keys: keys.into_iter().sorted().collect(),
+        headers: serialized_headers,
+    };
 
     Ok((
         BlockExecutionWitness {


### PR DESCRIPTION
Sort `state`, `codes`, and `keys` fields in `ExecutionWitness` before serialization. These were collected from HashMap/HashSet iterators with non-deterministic ordering, causing different VM inputs across runs on fresh runners leading to different instruction counts and segment boundaries.
