### PR TITLE
feat: cached root prover standalone benchmark

### DIFF
--- a/.github/workflows/compare-bench.yml
+++ b/.github/workflows/compare-bench.yml
@@ -22,6 +22,7 @@ on:
           - execute-metered
           - prove-app
           - prove-stark
+          - prove-root
           - prove-evm
         default: prove-stark
       block_number:

--- a/.github/workflows/compare-branches.yml
+++ b/.github/workflows/compare-branches.yml
@@ -23,6 +23,7 @@ on:
           - execute-metered
           - prove-app
           - prove-stark
+          - prove-root
           - prove-evm
         default: prove-stark
       block_number:

--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -43,6 +43,7 @@ on:
           - execute-metered
           - prove-app
           - prove-stark
+          - prove-root
           - prove-evm
         default: prove-stark
       profiling:
@@ -127,7 +128,7 @@ on:
       mode:
         type: string
         required: false
-        description: Running mode, one of {execute, execute-metered, prove-app, prove-stark, prove-evm}
+        description: Running mode, one of {execute, execute-metered, prove-app, prove-stark, prove-root, prove-evm}
         default: prove-stark
       profiling:
         type: string
@@ -325,7 +326,7 @@ jobs:
           fi
 
           MODE="${{ inputs.mode || github.event.inputs.mode }}"
-          if [[ "$MODE" == "prove-evm" ]]; then
+          if [[ "$MODE" == "prove-evm" || "$MODE" == "prove-root" ]]; then
             FEATURES="${FEATURES},evm-verify"
           fi
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "bytemuck",
  "num-bigint",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6541,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "halo2curves-axiom 0.7.2",
  "num-bigint",
@@ -6557,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6610,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -6619,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -6634,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "cargo_metadata 0.18.1",
  "eyre",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "abi_stable",
  "backtrace",
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6712,7 +6712,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6743,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#be134deac1f3ccbdc79844bddc9ae3525cf800ce"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4cbc6b23dc9569be78ad8fa0c1188a4f88adfa4a"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6754,7 +6754,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6783,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#be134deac1f3ccbdc79844bddc9ae3525cf800ce"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4cbc6b23dc9569be78ad8fa0c1188a4f88adfa4a"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -6808,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#be134deac1f3ccbdc79844bddc9ae3525cf800ce"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4cbc6b23dc9569be78ad8fa0c1188a4f88adfa4a"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6835,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#be134deac1f3ccbdc79844bddc9ae3525cf800ce"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4cbc6b23dc9569be78ad8fa0c1188a4f88adfa4a"
 dependencies = [
  "cc",
  "glob",
@@ -6844,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#be134deac1f3ccbdc79844bddc9ae3525cf800ce"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4cbc6b23dc9569be78ad8fa0c1188a4f88adfa4a"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6858,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6868,7 +6868,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -6911,7 +6911,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "eyre",
  "openvm-deferral-guest",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6980,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -7004,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-keccak256-guest",
  "spin 0.10.0",
@@ -7040,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-platform",
 ]
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7106,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "syn 2.0.102",
 ]
@@ -7114,7 +7114,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "group 0.13.0",
  "hex-literal",
@@ -7195,7 +7195,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7227,7 +7227,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "blstrs",
  "halo2curves-axiom 0.7.2",
@@ -7248,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -7261,7 +7261,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -7271,7 +7271,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -7289,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "derive-new 0.6.0",
  "eyre",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7437,7 +7437,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -7454,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7482,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7508,7 +7508,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "alloy-sol-types",
  "bitcode",
@@ -7551,7 +7551,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk-config"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "bon",
  "cfg-if",
@@ -7586,7 +7586,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm",
  "openvm-sha2-guest",
@@ -7596,7 +7596,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "ndarray",
  "num_enum",
@@ -7610,7 +7610,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7639,7 +7639,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-platform",
 ]
@@ -7647,7 +7647,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7661,7 +7661,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#be134deac1f3ccbdc79844bddc9ae3525cf800ce"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4cbc6b23dc9569be78ad8fa0c1188a4f88adfa4a"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -7696,7 +7696,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#be134deac1f3ccbdc79844bddc9ae3525cf800ce"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#4cbc6b23dc9569be78ad8fa0c1188a4f88adfa4a"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",
@@ -7782,7 +7782,7 @@ dependencies = [
 [[package]]
 name = "openvm-static-verifier"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "halo2-base",
  "itertools 0.14.0",
@@ -7806,7 +7806,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "elf",
  "eyre",
@@ -7821,7 +7821,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-host"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "bitcode",
  "eyre",
@@ -7860,7 +7860,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#f08f0fe28ce3fe62d2a71ce4a7abf45ca1d42ab4"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.1#b8194ef7a93d5abead2ef60d2ce9a38e2b287521"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -248,9 +248,6 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         p.exists().then_some(p)
     });
 
-    #[cfg(feature = "evm-verify")]
-    let root_pk_path = args.output_dir.join("root.pk");
-
     let mut sdk_builder = Sdk::builder();
 
     if let Some(p) = app_pk_path {
@@ -271,6 +268,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
 
     #[cfg(feature = "evm-verify")]
     {
+        let root_pk_path = args.output_dir.join("root.pk");
         if root_pk_path.exists() {
             info!("Loading root proving key from {}", root_pk_path.display());
             let root_pk = read_object_from_file(&root_pk_path)?;

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -137,6 +137,12 @@ pub struct HostArgs {
     #[arg(long, default_value = "output")]
     pub output_dir: PathBuf,
 
+    /// Optional directory used by prove-root to cache the intermediate stark proof. If set,
+    /// the stark proof is written to (or loaded from) <proof_cache>/stark.bitcode. If not
+    /// set, no proof caching is performed.
+    #[arg(long)]
+    pub proof_cache: Option<PathBuf>,
+
     /// If specified, loads the app proving key from this path.
     #[arg(long)]
     pub app_pk_path: Option<PathBuf>,
@@ -248,7 +254,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     let mut sdk_builder = Sdk::builder();
 
     if let Some(p) = app_pk_path {
-        let msg = format!("Loading app proving key from {}", p.display());
+        info!("Loading app proving key from {}", p.display());
         let app_pk = read_object_from_file(&p)?;
         sdk_builder = sdk_builder.app_pk(app_pk);
     } else {
@@ -256,7 +262,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     }
 
     if let Some(p) = agg_pk_path {
-        let msg = format!("Loading agg proving key from {}", p.display());
+        info!("Loading agg proving key from {}", p.display());
         let agg_pk = read_object_from_file(&p)?;
         sdk_builder = sdk_builder.agg_pk(agg_pk);
     } else {
@@ -266,7 +272,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     #[cfg(feature = "evm-verify")]
     {
         if root_pk_path.exists() {
-            let msg = format!("Loading root proving key from {}", root_pk_path.display());
+            info!("Loading root proving key from {}", root_pk_path.display());
             let root_pk = read_object_from_file(&root_pk_path)?;
             sdk_builder = sdk_builder.root_pk(root_pk);
         }
@@ -446,29 +452,25 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                 BenchMode::ProveRoot => {
                     let mut evm_prover = sdk.evm_prover_without_halo2(exe)?;
                     evm_prover.stark_prover.app_prover.set_program_name(&program_name);
-                    fs::create_dir_all(&args.output_dir)?;
 
-                    let proof_file = args.output_dir.join("stark.bitcode");
-                    let _root_proof = if proof_file.exists() {
+                    let proof_file = args.proof_cache.as_ref().map(|d| d.join("stark.bitcode"));
+                    let cached = proof_file.as_ref().filter(|p| p.exists());
+
+                    let _root_proof = if let Some(proof_file) = cached {
                         info!("Loading cached stark proof from: {}", proof_file.display());
                         let stark_proof_file =
-                            fs::File::open(&proof_file).expect("failed to open stark file");
+                            fs::File::open(proof_file).expect("failed to open stark file");
                         let mut stark_proof_reader = std::io::BufReader::new(stark_proof_file);
-
                         let (stark_proof, mut internal_meta) =
                             Decode::decode(&mut stark_proof_reader)
                                 .expect("failed stark proof deserialization");
-                        let root_proof = evm_prover
+                        evm_prover
                             .prove_unwrapped_with_stark_proof(stark_proof, &mut internal_meta)
-                            .expect(
-                                "failed to generate root proving ctx from deserialized stark proof",
-                            );
-                        root_proof
+                            .expect("failed to prove root from cached stark proof")
                     } else {
-                        info!(
-                            "No cached stark proof found at: {}; generating fresh",
-                            proof_file.display()
-                        );
+                        if let Some(p) = &proof_file {
+                            info!("No cached stark proof at {}; generating fresh", p.display());
+                        }
                         let (stark_proof, metadata) = evm_prover
                             .stark_prover
                             .prove(stdin, &[])
@@ -479,13 +481,18 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                                 &mut metadata.clone(),
                             )
                             .expect("failed to prove root");
-                        info!("Writing stark proof cache to: {}", proof_file.display());
-                        let stark_proof_file =
-                            fs::File::create(&proof_file).expect("failed to create stark file");
-                        let mut stark_proof_writer = std::io::BufWriter::new(stark_proof_file);
-                        (stark_proof, metadata)
-                            .encode(&mut stark_proof_writer)
-                            .expect("failed to write stark proof");
+                        if let Some(proof_file) = &proof_file {
+                            if let Some(parent) = proof_file.parent() {
+                                fs::create_dir_all(parent)?;
+                            }
+                            info!("Writing stark proof cache to: {}", proof_file.display());
+                            let stark_proof_file =
+                                fs::File::create(proof_file).expect("failed to create stark file");
+                            let mut stark_proof_writer = std::io::BufWriter::new(stark_proof_file);
+                            (stark_proof, metadata)
+                                .encode(&mut stark_proof_writer)
+                                .expect("failed to write stark proof");
+                        }
                         root_proof
                     };
                 }

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -37,7 +37,6 @@ use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE, FromElf};
 use openvm_verify_stark_host::{
     verify_vm_stark_proof_decoded,
     vk::{write_vk_to_file, VmStarkVerifyingKey},
-    VmStarkProof,
 };
 pub use reth_ethereum_primitives as reth_primitives;
 use tracing::{info, info_span};
@@ -464,24 +463,35 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                             fs::File::open(&proof_file).expect("failed to open stark file");
                         let mut stark_proof_reader = std::io::BufReader::new(stark_proof_file);
 
-                        let stark_proof = VmStarkProof::decode(&mut stark_proof_reader)
-                            .expect("failed stark proof deserialization");
-                        let ctx = evm_prover.root_prover.generate_proving_ctx(stark_proof).expect(
-                            "failed to generate root proving ctx from deserialized stark proof",
-                        );
-                        evm_prover.root_prover.prove_from_ctx(ctx)?
+                        let (stark_proof, mut internal_meta) =
+                            Decode::decode(&mut stark_proof_reader)
+                                .expect("failed stark proof deserialization");
+                        let root_proof = evm_prover
+                            .prove_unwrapped_with_stark_proof(stark_proof, &mut internal_meta)
+                            .expect(
+                                "failed to generate root proving ctx from deserialized stark proof",
+                            );
+                        root_proof
                     } else {
                         info!(
                             "No cached stark proof found at: {}; generating fresh",
                             proof_file.display()
                         );
-                        let (root_proof, stark_proof) =
-                            evm_prover.prove_unwrapped_with_agg_proof(stdin, &[])?;
+                        let (stark_proof, metadata) = evm_prover
+                            .stark_prover
+                            .prove(stdin, &[])
+                            .expect("failed to prove stark");
+                        let root_proof = evm_prover
+                            .prove_unwrapped_with_stark_proof(
+                                stark_proof.clone(),
+                                &mut metadata.clone(),
+                            )
+                            .expect("failed to prove root");
                         info!("Writing stark proof cache to: {}", proof_file.display());
                         let stark_proof_file =
                             fs::File::create(&proof_file).expect("failed to create stark file");
                         let mut stark_proof_writer = std::io::BufWriter::new(stark_proof_file);
-                        stark_proof
+                        (stark_proof, metadata)
                             .encode(&mut stark_proof_writer)
                             .expect("failed to write stark proof");
                         root_proof

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -13,7 +13,7 @@ use openvm_sdk::{
         AggregationSystemParams, AppConfig, DEFAULT_APP_LOG_BLOWUP, DEFAULT_APP_L_SKIP,
         DEFAULT_INTERNAL_LOG_BLOWUP, DEFAULT_LEAF_LOG_BLOWUP,
     },
-    fs::write_object_to_file,
+    fs::{read_object_from_file, write_object_to_file},
     Sdk, SC,
 };
 use openvm_sdk_config::{SdkVmConfig, TranspilerConfig};
@@ -25,7 +25,7 @@ use openvm_stark_sdk::{
     },
     openvm_stark_backend::{
         air_builders::symbolic::{SymbolicExpressionDag, SymbolicExpressionNode},
-        codec::Encode,
+        codec::{Decode, Encode},
         keygen::types::MultiStarkProvingKey,
         p3_field::PrimeCharacteristicRing,
     },
@@ -37,6 +37,7 @@ use openvm_transpiler::{elf::Elf, openvm_platform::memory::MEM_SIZE, FromElf};
 use openvm_verify_stark_host::{
     verify_vm_stark_proof_decoded,
     vk::{write_vk_to_file, VmStarkVerifyingKey},
+    VmStarkProof,
 };
 pub use reth_ethereum_primitives as reth_primitives;
 use tracing::{info, info_span};
@@ -61,6 +62,8 @@ pub enum BenchMode {
     ProveApp,
     /// Generate a full end-to-end STARK proof with aggregation.
     ProveStark,
+    #[cfg(feature = "evm-verify")]
+    ProveRoot,
     /// Generate a full end-to-end halo2 proof for EVM verifier.
     #[cfg(feature = "evm-verify")]
     ProveEvm,
@@ -81,6 +84,8 @@ impl std::fmt::Display for BenchMode {
             Self::ExecuteMetered => write!(f, "execute_metered"),
             Self::ProveApp => write!(f, "prove_app"),
             Self::ProveStark => write!(f, "prove_stark"),
+            #[cfg(feature = "evm-verify")]
+            Self::ProveRoot => write!(f, "prove_root"),
             #[cfg(feature = "evm-verify")]
             Self::ProveEvm => write!(f, "prove_evm"),
             Self::Keygen => write!(f, "keygen"),
@@ -194,6 +199,14 @@ pub fn reth_vm_config() -> SdkVmConfig {
 
 const VM_MAX_CONSTRAINT_DEGREE: usize = 4;
 
+fn eprint_time<R>(msg: &str, f: impl FnOnce() -> R) -> R {
+    eprint!("{msg} ... ");
+    let start = Instant::now();
+    let result = f();
+    eprintln!("done in {:.3}s", start.elapsed().as_secs_f64());
+    result
+}
+
 pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) -> eyre::Result<()> {
     // Initialize the environment variables.
     dotenv::dotenv().ok();
@@ -218,13 +231,6 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         tracing::debug!("air_idx={air_idx} | {}", air.name());
     }
 
-    if args.app_pk_path.is_some() != args.agg_pk_path.is_some() {
-        eyre::bail!("app_pk_path and agg_pk_path must be provided together");
-    }
-    if let Some(_app_pk_path) = args.app_pk_path {
-        todo!();
-    }
-
     let transpiler = vm_config.transpiler().clone();
 
     let app_params = app_params_with_100_bits_security(DEFAULT_LOG_STACKED_HEIGHT);
@@ -232,7 +238,50 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     // Setup: this can all be done once before receiving proof input
     let app_config = AppConfig::new(vm_config, app_params);
     let agg_params = AggregationSystemParams::default();
-    let sdk = Sdk::new(app_config, agg_params)?;
+
+    // Resolve key paths: explicit flag wins; otherwise fall back to <output_dir>/<name>.pk
+    // if the file exists. The chain agg->app and root->agg->app is enforced by the builder,
+    // so skip later stages whenever an earlier stage isn't available.
+    let app_pk_path = args.app_pk_path.clone().or_else(|| {
+        let p = args.output_dir.join("app.pk");
+        p.exists().then_some(p)
+    });
+    let agg_pk_path = args.agg_pk_path.clone().or_else(|| {
+        let p = args.output_dir.join("agg.pk");
+        p.exists().then_some(p)
+    });
+
+    #[cfg(feature = "evm-verify")]
+    let root_pk_path = args.output_dir.join("root.pk");
+
+    let mut sdk_builder = Sdk::builder();
+
+    if let Some(p) = app_pk_path {
+        let msg = format!("Loading app proving key from {}", p.display());
+        let app_pk = eprint_time(&msg, || read_object_from_file(&p))?;
+        sdk_builder = sdk_builder.app_pk(app_pk);
+    } else {
+        sdk_builder = sdk_builder.app_config(app_config);
+    }
+
+    if let Some(p) = agg_pk_path {
+        let msg = format!("Loading agg proving key from {}", p.display());
+        let agg_pk = eprint_time(&msg, || read_object_from_file(&p))?;
+        sdk_builder = sdk_builder.agg_pk(agg_pk);
+    } else {
+        sdk_builder = sdk_builder.agg_params(agg_params);
+    }
+
+    #[cfg(feature = "evm-verify")]
+    {
+        if root_pk_path.exists() {
+            let msg = format!("Loading root proving key from {}", root_pk_path.display());
+            let root_pk = eprint_time(&msg, || read_object_from_file(&root_pk_path))?;
+            sdk_builder = sdk_builder.root_pk(root_pk);
+        }
+    }
+
+    let sdk = sdk_builder.build()?;
 
     if matches!(args.mode, BenchMode::DumpAirStats) {
         dump_air_stats(&sdk, &args.air_stats_path)?;
@@ -250,7 +299,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         };
         let vk_path = PathBuf::from("reth.vm.vk");
         write_vk_to_file(&vk_path, &vk)?;
-        info!("VM verifying key written to {}", vk_path.display());
+        eprintln!("VM verifying key written to {}", vk_path.display());
         return Ok(());
     }
 
@@ -334,7 +383,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                 fs::create_dir_all(parent)?;
             }
             fs::write(path, serde_json::to_string(&json)?)?;
-            info!("Wrote input JSON to {}", path.display());
+            eprintln!("Wrote input JSON to {}", path.display());
         } else {
             println!("{}", serde_json::to_string_pretty(&json)?);
         }
@@ -352,7 +401,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         })?;
         let elapsed = start.elapsed();
         let block_hash = header.hash_slow();
-        info!("Host execution: {:.6}s, block hash: {}", elapsed.as_secs_f64(), block_hash,);
+        eprintln!("Host execution: {:.6}s, block hash: {}", elapsed.as_secs_f64(), block_hash);
         println!("BENCH_HOST_NS={}", elapsed.as_nanos());
         println!("BENCH_BLOCK_HASH={block_hash}");
         return Ok(());
@@ -403,6 +452,42 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                     verify_vm_stark_proof_decoded(&vk, &proof)?;
                 }
                 #[cfg(feature = "evm-verify")]
+                BenchMode::ProveRoot => {
+                    let mut evm_prover = sdk.evm_prover_without_halo2(exe)?;
+                    evm_prover.stark_prover.app_prover.set_program_name(&program_name);
+                    fs::create_dir_all(&args.output_dir)?;
+
+                    let proof_file = args.output_dir.join("stark.bitcode");
+                    let _root_proof = if proof_file.exists() {
+                        info!("Loading cached stark proof from: {}", proof_file.display());
+                        let stark_proof_file =
+                            fs::File::open(&proof_file).expect("failed to open stark file");
+                        let mut stark_proof_reader = std::io::BufReader::new(stark_proof_file);
+
+                        let stark_proof = VmStarkProof::decode(&mut stark_proof_reader)
+                            .expect("failed stark proof deserialization");
+                        let ctx = evm_prover.root_prover.generate_proving_ctx(stark_proof).expect(
+                            "failed to generate root proving ctx from deserialized stark proof",
+                        );
+                        evm_prover.root_prover.prove_from_ctx(ctx)?
+                    } else {
+                        info!(
+                            "No cached stark proof found at: {}; generating fresh",
+                            proof_file.display()
+                        );
+                        let (root_proof, stark_proof) =
+                            evm_prover.prove_unwrapped_with_agg_proof(stdin, &[])?;
+                        info!("Writing stark proof cache to: {}", proof_file.display());
+                        let stark_proof_file =
+                            fs::File::create(&proof_file).expect("failed to create stark file");
+                        let mut stark_proof_writer = std::io::BufWriter::new(stark_proof_file);
+                        stark_proof
+                            .encode(&mut stark_proof_writer)
+                            .expect("failed to write stark proof");
+                        root_proof
+                    };
+                }
+                #[cfg(feature = "evm-verify")]
                 BenchMode::ProveEvm => {
                     let mut evm_prover = sdk.evm_prover(exe)?;
                     evm_prover.stark_prover.app_prover.set_program_name(&program_name);
@@ -425,6 +510,9 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                     let agg_pk_path =
                         args.agg_pk_path.unwrap_or_else(|| args.output_dir.join("agg.pk"));
 
+                    #[cfg(feature = "evm-verify")]
+                    let root_pk_path = args.output_dir.join("root.pk");
+
                     info!("Generating app proving key...");
                     let (app_pk, app_vk) = sdk.app_keygen();
 
@@ -433,6 +521,14 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
 
                     info!("Saving app verifying key to: {}", app_vk_path.display());
                     write_object_to_file(&app_vk_path, &app_vk)?;
+
+                    #[cfg(feature = "evm-verify")]
+                    {
+                        info!("Generating root proving key...");
+                        let root_pk = sdk.root_pk();
+                        info!("Saving app root key to: {}", root_pk_path.display());
+                        write_object_to_file(&root_pk_path, &root_pk)?;
+                    }
 
                     info!("Generating aggregation proving key...");
                     let agg_pk = sdk.agg_pk();
@@ -444,6 +540,8 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                     info!("  App PK: {}", app_pk_path.display());
                     info!("  App VK: {}", app_vk_path.display());
                     info!("  Agg PK: {}", agg_pk_path.display());
+                    #[cfg(feature = "evm-verify")]
+                    info!("  Root PK: {}", root_pk_path.display());
                 }
                 _ => {
                     // MakeInput, ExecuteHost, GenerateVmVkey, DumpAirStats handled earlier
@@ -470,7 +568,7 @@ fn dump_air_stats(sdk: &Sdk, output_path: &PathBuf) -> eyre::Result<()> {
     let agg_pk = sdk.agg_pk();
     dump_pk_stats("agg_leaf", &agg_pk.prefix.leaf, &mut file)?;
 
-    info!("AIR statistics written to {}", output_path.display());
+    eprintln!("AIR statistics written to {}", output_path.display());
     Ok(())
 }
 

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -198,14 +198,6 @@ pub fn reth_vm_config() -> SdkVmConfig {
 
 const VM_MAX_CONSTRAINT_DEGREE: usize = 4;
 
-fn eprint_time<R>(msg: &str, f: impl FnOnce() -> R) -> R {
-    eprint!("{msg} ... ");
-    let start = Instant::now();
-    let result = f();
-    eprintln!("done in {:.3}s", start.elapsed().as_secs_f64());
-    result
-}
-
 pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) -> eyre::Result<()> {
     // Initialize the environment variables.
     dotenv::dotenv().ok();
@@ -257,7 +249,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
 
     if let Some(p) = app_pk_path {
         let msg = format!("Loading app proving key from {}", p.display());
-        let app_pk = eprint_time(&msg, || read_object_from_file(&p))?;
+        let app_pk = read_object_from_file(&p)?;
         sdk_builder = sdk_builder.app_pk(app_pk);
     } else {
         sdk_builder = sdk_builder.app_config(app_config);
@@ -265,7 +257,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
 
     if let Some(p) = agg_pk_path {
         let msg = format!("Loading agg proving key from {}", p.display());
-        let agg_pk = eprint_time(&msg, || read_object_from_file(&p))?;
+        let agg_pk = read_object_from_file(&p)?;
         sdk_builder = sdk_builder.agg_pk(agg_pk);
     } else {
         sdk_builder = sdk_builder.agg_params(agg_params);
@@ -275,7 +267,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     {
         if root_pk_path.exists() {
             let msg = format!("Loading root proving key from {}", root_pk_path.display());
-            let root_pk = eprint_time(&msg, || read_object_from_file(&root_pk_path))?;
+            let root_pk = read_object_from_file(&root_pk_path)?;
             sdk_builder = sdk_builder.root_pk(root_pk);
         }
     }
@@ -298,7 +290,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         };
         let vk_path = PathBuf::from("reth.vm.vk");
         write_vk_to_file(&vk_path, &vk)?;
-        eprintln!("VM verifying key written to {}", vk_path.display());
+        info!("VM verifying key written to {}", vk_path.display());
         return Ok(());
     }
 
@@ -382,7 +374,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                 fs::create_dir_all(parent)?;
             }
             fs::write(path, serde_json::to_string(&json)?)?;
-            eprintln!("Wrote input JSON to {}", path.display());
+            info!("Wrote input JSON to {}", path.display());
         } else {
             println!("{}", serde_json::to_string_pretty(&json)?);
         }
@@ -400,7 +392,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         })?;
         let elapsed = start.elapsed();
         let block_hash = header.hash_slow();
-        eprintln!("Host execution: {:.6}s, block hash: {}", elapsed.as_secs_f64(), block_hash);
+        info!("Host execution: {:.6}s, block hash: {}", elapsed.as_secs_f64(), block_hash);
         println!("BENCH_HOST_NS={}", elapsed.as_nanos());
         println!("BENCH_BLOCK_HASH={block_hash}");
         return Ok(());
@@ -578,7 +570,7 @@ fn dump_air_stats(sdk: &Sdk, output_path: &PathBuf) -> eyre::Result<()> {
     let agg_pk = sdk.agg_pk();
     dump_pk_stats("agg_leaf", &agg_pk.prefix.leaf, &mut file)?;
 
-    eprintln!("AIR statistics written to {}", output_path.display());
+    info!("AIR statistics written to {}", output_path.display());
     Ok(())
 }
 

--- a/run.sh
+++ b/run.sh
@@ -32,13 +32,13 @@ set -e
 REPO_ROOT=$(git rev-parse --show-toplevel)
 WORKDIR=$REPO_ROOT
 
-cd "$REPO_ROOT/bin/stateless-guest"
-OPENVM_RUST_TOOLCHAIN=nightly-2026-01-18 cargo openvm build
-mkdir -p ../reth-benchmark/elf
-SRC="target/riscv32im-risc0-zkvm-elf/release/openvm-stateless-guest"
-DEST="../reth-benchmark/elf/openvm-stateless-guest"
+DEST="$REPO_ROOT/bin/reth-benchmark/elf/openvm-stateless-guest"
 
-if [ ! -f "$DEST" ] || ! cmp -s "$SRC" "$DEST"; then
+if [ ! -f "$DEST" ]; then
+    cd "$REPO_ROOT/bin/stateless-guest"
+    OPENVM_RUST_TOOLCHAIN=nightly-2026-01-18 cargo openvm build
+    mkdir -p ../reth-benchmark/elf
+    SRC="target/riscv32im-risc0-zkvm-elf/release/openvm-stateless-guest"
     cp "$SRC" "$DEST"
 fi
 
@@ -223,8 +223,15 @@ fi
 if [ "$USE_NSYS" = "true" ]; then
     FEATURES="$FEATURES,nvtx"
 fi
-if [ "$MODE" = "prove-evm" ]; then
+if [ "$MODE" = "prove-evm" ] || [ "$MODE" = "prove-root" ] || [ "$MODE" = "keygen-root" ]; then
     FEATURES="$FEATURES,evm-verify"
+fi
+
+# `keygen-root` is a shell-level alias: enable evm-verify (handled above) and pass --mode keygen
+# to the binary. The keygen branch then additionally writes <output_dir>/root.pk when evm-verify
+# is compiled in.
+if [ "$MODE" = "keygen-root" ]; then
+    MODE="keygen"
 fi
 
 arch=$(uname -m)

--- a/run.sh
+++ b/run.sh
@@ -15,6 +15,9 @@
 #   --perf              Run with perf + samply host profiling and upload to Firefox Profiler
 #   --nsys              Run with nsys profiling and output summary stats
 #   --<tool>            Run with compute-sanitizer --tool <tool> where tool is one of memcheck, synccheck, or racecheck
+#   --proof-cache <DIR> Directory to cache the intermediate stark proof for prove-root mode.
+#                       If set, the stark proof is stored at <DIR>/stark.bitcode and reused
+#                       on subsequent runs. If unset, no proof caching is performed.
 #
 # Examples:
 #   ./run.sh                              # Run with defaults
@@ -138,6 +141,10 @@ while [[ $# -gt 0 ]]; do
             exit 1
             fi
             launch_count="$2"
+            shift 2
+            ;;
+        --proof-cache)
+            PROOF_CACHE="$2"
             shift 2
             ;;
         --memcheck)
@@ -290,6 +297,10 @@ if [[ -n $APP_L_SKIP ]]
 then
     CONFIG_ARGS="$CONFIG_ARGS --app-l-skip ${APP_L_SKIP}"
 fi
+if [[ -n $PROOF_CACHE ]]
+then
+    CONFIG_ARGS="$CONFIG_ARGS --proof-cache ${PROOF_CACHE}"
+fi
 
 BIN_ARGS="--mode $MODE \
 --max-segment-length $MAX_SEGMENT_LENGTH \
@@ -308,6 +319,8 @@ fi
 
 export RUST_LOG="info,p3_=warn"
 
+echo "Run command:"
+echo "$BIN $BIN_ARGS"
 if [ "$USE_PERF" = "true" ]; then
     # Set sampling frequency based on mode
     if [[ "$MODE" == "execute-host" || "$MODE" == "execute" || "$MODE" == "execute-metered" ]]; then
@@ -318,11 +331,11 @@ if [ "$USE_PERF" = "true" ]; then
 
     echo "Running with perf profiling (freq=${PERF_FREQ})..."
     export OUTPUT_PATH="metrics.json"
-    perf record -F $PERF_FREQ --call-graph=fp -g -o perf.data -- $BIN $BIN_ARGS
+    perf record -F $PERF_FREQ --call-graph=dwarf -g -o perf.data -- $BIN $BIN_ARGS
 
     echo "Converting perf.data with samply..."
     mkdir -p samply_profile
-    samply import perf.data --presymbolicate --save-only --output samply_profile/profile.json.gz
+    samply import perf.data --unstable-presymbolicate --save-only --output samply_profile/profile.json.gz
     echo "Saved profile: samply_profile/profile.json.gz"
 
     FIREFOX_PROFILER_URL=$(python3 "$REPO_ROOT/scripts/upload_firefox_profile.py" samply_profile/profile.json.gz) || true


### PR DESCRIPTION
This PR makes it so that the root prover can be benchmarked individually, doing so requires a few minor changes to the sdk on https://github.com/openvm-org/openvm/pull/2799. 

It also adds support for loading cache keys. 

First you would dump the keys and stark proof 
```
> ./run.sh --block 21345144 --mode keygen-root
> ls output
agg.pk  app.pk  app.vk  root.pk  stark.bitcode
```

Then run the root prover
```
./run.sh --block 21345144 --mode prove-root
```

# Outputs

```
Using CUDA acceleration (nvidia-smi detected a CUDA-capable GPU).
Recording GPU memory usage to /home/allanl/Programs/openvm-eth-worktree/root_bench/gpu_memory_usage.csv (interval: 5s).
CUDA Backend Enabled
INFO reth-block [ 30.3s | 0.97% / 100.00% ] block_number: 21345144
INFO ┝━ transport_pk_to_device [ 727ms | 2.40% ]
INFO ┝━ stacked_commit [ 23.6ms | 0.00% / 0.08% ]
INFO │  ┝━ ｉ [info]: GPU mem: used=+0 B, current=845.4 MiB, peak=845.4 MiB, in pool=788.0 MiB (prover.stacked_commit:before stacked_commit)
INFO │  ┝━ ｉ [info]: stacked_matrix_dimensions | height: 16777216 | width: 1
INFO │  ┝━ rs_code_matrix [ 4.57ms | 0.02% ]
INFO │  │  ┕━ ｉ [info]: GPU mem: used=+128.0 MiB, current=973.4 MiB, peak=973.4 MiB, in pool=916.0 MiB (prover.rs_code_matrix)
INFO │  ┝━ merkle_tree [ 19.0ms | 0.06% ]
INFO │  │  ┕━ ｉ [info]: GPU mem: used=+128.0 MiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.0 GiB (prover.merkle_tree)
INFO │  ┕━ ｉ [info]: GPU mem: used=+256.0 MiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.0 GiB (prover.stacked_commit)
INFO ┝━ ｉ [info]: Loading cached stark proof from: output/stark.bitcode
INFO ┝━ tracegen_attempt [ 33.7ms | 0.01% / 0.11% ] group: "root"
INFO │  ┕━ subcircuit_generate_proving_ctxs [ 32.0ms | 0.01% / 0.11% ]
INFO │     ┝━ execute_preflight [ 2.48ms | 0.01% ]
INFO │     ┝━ apply_merkle_precomputation [ 12.2ms | 0.00% / 0.04% ]
INFO │     │  ┕━ compute_merkle_precomputation_cuda [ 12.2ms | 0.04% ]
INFO │     ┝━ generate_proving_ctxs [ 8.12ms | 0.02% / 0.03% ]
INFO │     │  ┕━ generate_blob [ 708µs | 0.00% ]
INFO │     ┝━ generate_proving_ctxs [ 2.03ms | 0.01% / 0.01% ]
INFO │     │  ┕━ generate_blob [ 369µs | 0.00% ]
INFO │     ┝━ generate_proving_ctxs [ 165µs | 0.00% ]
INFO │     │  ┝━ ｉ [info]: GPU mem: used=+11.0 KiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.proof_shape)
INFO │     │  ┝━ ｉ [info]: GPU mem: used=+4.0 KiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.public_values)
INFO │     │  ┕━ ｉ [info]: GPU mem: used=+0 B, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.range_checker)
INFO │     ┝━ generate_proving_ctxs [ 384µs | 0.00% / 0.00% ]
INFO │     │  ┕━ generate_blob [ 26.5µs | 0.00% ]
INFO │     ┝━ generate_proving_ctxs [ 2.24ms | 0.01% ]
INFO │     ┝━ generate_proving_ctxs [ 457µs | 0.00% / 0.00% ]
INFO │     │  ┝━ generate_blob [ 225µs | 0.00% ]
INFO │     │  ┝━ ｉ [info]: GPU mem: used=+2.8 MiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.whir_initial_opened_values)
INFO │     │  ┝━ ｉ [info]: GPU mem: used=+112.0 KiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.whir_non_initial_opened_values)
INFO │     │  ┝━ ｉ [info]: GPU mem: used=+248.0 KiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.whir_folding)
INFO │     │  ┕━ ｉ [info]: GPU mem: used=+2.8 MiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.whir_final_poly_query_eval)
INFO │     ┝━ ｉ [info]: GPU mem: used=+512 B, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.pow_checker)
INFO │     ┕━ ｉ [info]: GPU mem: used=+512.0 KiB, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (tracegen.exp_bits_len)
INFO ┕━ agg_layer [ 29.2s | 0.00% / 96.44% ] group: "root"
INFO    ┕━ root [ 29.2s | 0.00% / 96.44% ]
INFO       ┕━ total_proof [ 29.2s | 0.00% / 96.44% ]
INFO          ┝━ transport_pk_to_device [ 116ms | 0.38% ]
INFO          ┕━ stark_prove_excluding_trace [ 29.1s | 0.00% / 96.06% ] phase: "prover"
INFO             ┝━ ｉ [info]:  | num_airs_present: 42
INFO             ┝━ prover.main_trace_commit [ 440ms | 0.00% / 1.45% ] phase: "prover"
INFO             │  ┝━ stacked_commit [ 439ms | 0.00% / 1.45% ]
INFO             │  │  ┝━ ｉ [info]: GPU mem: used=+0 B, current=1.1 GiB, peak=1.1 GiB, in pool=1.1 GiB (prover.stacked_commit:before stacked_commit)
INFO             │  │  ┝━ ｉ [info]: stacked_matrix_dimensions | height: 1048576 | width: 18
INFO             │  │  ┝━ rs_code_matrix [ 40.3ms | 0.13% ]
INFO             │  │  │  ┕━ ｉ [info]: GPU mem: used=+1.1 GiB, current=2.3 GiB, peak=2.3 GiB, in pool=2.2 GiB (prover.rs_code_matrix)
INFO             │  │  ┝━ merkle_tree [ 399ms | 1.32% ]
INFO             │  │  │  ┕━ ｉ [info]: GPU mem: used=+64.0 MiB, current=2.3 GiB, peak=2.3 GiB, in pool=2.3 GiB (prover.merkle_tree)
INFO             │  │  ┕━ ｉ [info]: GPU mem: used=+1.2 GiB, current=2.3 GiB, peak=2.3 GiB, in pool=2.3 GiB (prover.stacked_commit)
INFO             │  ┝━ ｉ [info]: total_trace_cells = 18_533_606 (excluding preprocessed)
INFO             │  ┝━ ｉ [info]: preprocessed_trace_cells = 0
INFO             │  ┕━ ｉ [info]: main_trace_cells = 18_533_606
INFO             ┝━ prover.rap_constraints [ 5.14s | 0.00% / 16.94% ] phase: "prover"
INFO             │  ┝━ prove_zerocheck_and_logup_gpu [ 5.14s | 0.00% / 16.94% ]
INFO             │  │  ┝━ prover.rap_constraints.logup_gkr [ 5.06s | 16.61% / 16.69% ] phase: "prover"
INFO             │  │  │  ┝━ ｉ [info]:  | n_global: 19 | n_logup: 19
INFO             │  │  │  ┝━ prover.rap_constraints.logup_gkr.input_evals [ 3.72ms | 0.01% ]
INFO             │  │  │  ┕━ fractional_sumcheck_gpu [ 20.3ms | 0.07% ]
INFO             │  │  │     ┝━ ｉ [info]: GPU mem: used=+36.0 MiB, current=2.4 GiB, peak=2.4 GiB, in pool=2.3 GiB (prover.logup_zerocheck_prover:fractional_sumcheck_gkr: after building segment tree)
INFO             │  │  │     ┕━ ｉ [info]: GPU mem: used=+164.1 MiB, current=2.5 GiB, peak=2.5 GiB, in pool=2.4 GiB (prover.logup_zerocheck_prover:after_fractional_sumcheck_gkr)
INFO             │  │  ┝━ prover.rap_constraints.round0 [ 28.7ms | 0.00% / 0.09% ] phase: "prover"
INFO             │  │  │  ┝━ prover.rap_constraints.ple_round0 [ 27.4ms | 0.09% ]
INFO             │  │  │  ┕━ s'_0 -> s_0 cpu interpolations [ 428µs | 0.00% ]
INFO             │  │  ┕━ prover.rap_constraints.mle_rounds [ 48.5ms | 0.05% / 0.16% ] phase: "prover"
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 18.6ms | 0.06% ] round: 1
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 2.82ms | 0.01% ] round: 2
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 2.40ms | 0.01% ] round: 3
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 1.97ms | 0.01% ] round: 4
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 1.90ms | 0.01% ] round: 5
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 2.02ms | 0.01% ] round: 6
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 463µs | 0.00% ] round: 7
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 388µs | 0.00% ] round: 8
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 360µs | 0.00% ] round: 9
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 331µs | 0.00% ] round: 10
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 290µs | 0.00% ] round: 11
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 240µs | 0.00% ] round: 12
INFO             │  │     ┝━ LogupZerocheck::sumcheck_polys_batch_eval [ 187µs | 0.00% ] round: 13
INFO             │  │     ┕━ ｉ [info]: GPU mem: used=+0 B, current=2.3 GiB, peak=2.7 GiB, in pool=2.6 GiB (prover.logup_zerocheck_prover)
INFO             │  ┕━ ｉ [info]: GPU mem: used=+144 B, current=2.3 GiB, peak=2.7 GiB, in pool=2.6 GiB (prover.rap_constraints)
INFO             ┕━ prover.openings [ 23.5s | 0.00% / 77.66% ] phase: "prover"
INFO                ┝━ prover.openings.stacked_reduction [ 6.84ms | 0.00% / 0.02% ] phase: "prover"
INFO                │  ┝━ prover.openings.stacked_reduction.round0 [ 1.24ms | 0.00% ] phase: "prover"
INFO                │  │  ┕━ ｉ [info]: GPU mem: used=+8.4 MiB, current=2.3 GiB, peak=2.3 GiB, in pool=2.6 GiB (prover.stacked_reduction_new:stacked_reduction_sumcheck round 0)
INFO                │  ┝━ prover.openings.stacked_reduction.mle_rounds [ 5.55ms | 0.02% ] phase: "prover"
INFO                │  ┕━ ｉ [info]: GPU mem: used=+0 B, current=2.3 GiB, peak=2.5 GiB, in pool=2.6 GiB (prover.stacked_reduction_new)
INFO                ┝━ prover.openings.whir [ 23.5s | 76.87% / 77.64% ] phase: "prover"
INFO                │  ┝━ ｉ [info]: GPU mem: used=-40.4 MiB, current=2.3 GiB, peak=2.5 GiB, in pool=2.6 GiB (prover.prove_whir_opening:before_whir_rounds)
INFO                │  ┝━ merkle_tree [ 154ms | 0.51% ]
INFO                │  │  ┕━ ｉ [info]: GPU mem: used=+32.0 MiB, current=2.4 GiB, peak=2.5 GiB, in pool=2.6 GiB (prover.merkle_tree)
INFO                │  ┝━ batch_open_rows [ 184µs | 0.00% / 0.00% ]
INFO                │  │  ┕━ opened_rows_d2h [ 52.7µs | 0.00% ]
INFO                │  ┝━ ｉ [info]: GPU mem: used=-1.1 GiB, current=1.2 GiB, peak=2.5 GiB, in pool=2.6 GiB (prover.prove_whir_opening:after_initial_whir_round)
INFO                │  ┝━ merkle_tree [ 80.6ms | 0.27% ]
INFO                │  │  ┕━ ｉ [info]: GPU mem: used=+16.0 MiB, current=1.3 GiB, peak=2.5 GiB, in pool=2.6 GiB (prover.merkle_tree)
INFO                │  ┝━ batch_open_rows [ 171µs | 0.00% / 0.00% ]
INFO                │  │  ┕━ opened_rows_d2h [ 33.3µs | 0.00% ]
INFO                │  ┝━ batch_open_rows [ 94.8µs | 0.00% / 0.00% ]
INFO                │  │  ┕━ opened_rows_d2h [ 18.2µs | 0.00% ]
INFO                │  ┕━ ｉ [info]: GPU mem: used=-1.3 GiB, current=1.1 GiB, peak=2.5 GiB, in pool=2.6 GiB (prover.prove_whir_opening)
INFO                ┕━ ｉ [info]: GPU mem: used=-1.3 GiB, current=1.1 GiB, peak=1.1 GiB, in pool=2.6 GiB (prover.openings)
Peak GPU memory usage: 3.34 GB (logged to /home/allanl/Programs/openvm-eth-worktree/root_bench/gpu_memory_usage.csv)
```

Resolves INT-7744