### PR TITLE
fix: witness gen race condition in reorgs

### DIFF
--- a/crates/stateless-witness/src/error.rs
+++ b/crates/stateless-witness/src/error.rs
@@ -1,11 +1,18 @@
 use reth_evm::block::BlockExecutionError;
-use reth_revm::primitives::alloy_primitives::BlockNumber;
+use reth_revm::primitives::alloy_primitives::B256;
 use reth_storage_errors::provider::ProviderError;
 
 #[derive(thiserror::Error, Debug)]
 pub enum WitnessError {
-    #[error("parent block not found for block number {0}")]
-    ParentBlockNotFound(BlockNumber),
+    #[error("parent block not found for block hash {0}")]
+    ParentBlockNotFound(B256),
+
+    #[error(
+        "witness is missing the state trie root node for parent state root {0}; the witness \
+         `state` and `parent_state_root` describe different snapshots (e.g. a reorg during \
+         witness generation)"
+    )]
+    StateRootNodeMissing(B256),
 
     #[error("provider error: {0}")]
     Provider(#[from] ProviderError),

--- a/crates/stateless-witness/src/lib.rs
+++ b/crates/stateless-witness/src/lib.rs
@@ -1,7 +1,7 @@
 //! Crate providing middleware for Reth stateless [ExecutionWitness] generation and conversion to
 //! the input format used by the OpenVM stateless executor. The provided functions are intended for
 //! use either within the Reth SDK, as part of a Reth ExEx, or by Reth RPC clients.
-use alloy_consensus::Header;
+use alloy_consensus::{BlockHeader as _, Header};
 use alloy_rlp::Encodable;
 use alloy_rpc_types_debug::ExecutionWitness;
 use openvm_mpt::{resolver::MptResolver, EthereumState};
@@ -14,10 +14,10 @@ use reth_ethereum_primitives::Block;
 use reth_evm::{execute::Executor, ConfigureEvm};
 use reth_node_api::{FullNodeComponents, NodeTypes};
 use reth_primitives_traits::{NodePrimitives, RecoveredBlock};
-use reth_provider::{BlockReaderIdExt, HeaderProvider, StateProviderFactory};
+use reth_provider::{HeaderProvider, StateProviderFactory};
 use reth_revm::{
     database::StateProviderDatabase,
-    primitives::{alloy_primitives::BlockNumber, keccak256, Bytes, HashMap, B256},
+    primitives::{keccak256, Bytes, HashMap, B256},
     state::Bytecode,
     witness::ExecutionWitnessRecord,
     State,
@@ -98,7 +98,6 @@ pub fn generate_stateless_input_from_witness_and_ancestor_headers(
 pub fn generate_block_execution_witness<Node>(
     provider: Node::Provider,
     evm_config: Node::Evm,
-    number: BlockNumber,
     recovered_block: RecoveredBlock<
         <<Node::Types as NodeTypes>::Primitives as NodePrimitives>::Block,
     >,
@@ -106,12 +105,12 @@ pub fn generate_block_execution_witness<Node>(
 where
     Node: FullNodeComponents<Types: NodeTypes<Primitives = EthPrimitives>>,
 {
-    let parent_block_number = number - 1;
+    let number = recovered_block.number;
 
-    let parent_block = provider
-        .block_by_id(parent_block_number.into())?
-        .ok_or(WitnessError::ParentBlockNotFound(parent_block_number))?;
-    let state_provider = provider.state_by_block_id(parent_block_number.into())?;
+    let parent_hash = recovered_block.parent_hash();
+    let parent_header =
+        provider.header(parent_hash)?.ok_or(WitnessError::ParentBlockNotFound(parent_hash))?;
+    let state_provider = provider.state_by_block_hash(parent_hash)?;
     let db = StateProviderDatabase::new(&state_provider);
     let executor = evm_config.executor(db);
     let mut witness_record = ExecutionWitnessRecord::default();
@@ -164,7 +163,7 @@ where
     Ok((
         BlockExecutionWitness {
             execution_witness,
-            parent_state_root: parent_block.state_root,
+            parent_state_root: parent_header.state_root(),
             current_block: recovered_block.into_block(),
         },
         ancestor_headers,
@@ -178,9 +177,23 @@ pub fn resolve_ethereum_state(
     keys: Vec<Bytes>,
 ) -> WitnessResult<EthereumState> {
     let mut node_store = Vec::with_capacity(reth_state.len());
+    let mut has_state_root_node = state_root == EMPTY_ROOT_HASH;
     for node in reth_state {
-        node_store.push((keccak256(&node), node));
+        let hash = keccak256(&node);
+        has_state_root_node |= hash == state_root;
+        node_store.push((hash, node));
     }
+
+    // Explicit guard: the witness must contain the state-trie root node hashing to
+    // `state_root`. If it's absent, the witness `state` and `parent_state_root` come from
+    // different snapshots (e.g. a reorg split the two provider reads during witness
+    // generation). Fail loudly here with the expected root rather than letting the resolver
+    // stub the root as an unresolved `Digest` and surface later as an opaque
+    // "reached an unresolved node" deep inside a `get_rlp` traversal.
+    if !has_state_root_node {
+        return Err(WitnessError::StateRootNodeMissing(state_root));
+    }
+
     let mpt_resolver = MptResolver::from_iter(node_store);
 
     let state_trie = mpt_resolver.resolve(&state_root)?;


### PR DESCRIPTION
## Summary

`generate_block_execution_witness` reads the parent **header** and the parent **state** as two separate, non-atomic queries keyed by block *number*. If the canonical chain changes between those two reads (a reorg at the parent height), the resulting `BlockExecutionWitness` pairs a `parent_state_root` from one chain view with `execution_witness.state` nodes from another. The witness is internally fine, but the two pieces describe **different state snapshots**.

Downstream, `resolve_ethereum_state` can't find the trie node hashing to `parent_state_root`, stubs it as an unresolved placeholder, and the first account lookup fails with a confusing error:

```
MPT error: reached an unresolved node: 0x1004…53d4
```

This is **not** a bug in the MPT resolver and **not** a serialization problem. It's a consistency bug in how the witness is assembled.

## Symptom

Running stateless-input generation on the archived witness for block **25180499** fails:

```
Generating StatelessExecutorInput...
Error:
   0: MPT error: reached an unresolved node: 0x1004…53d4
   1: reached an unresolved node: 0x1004…53d4
```

The error originates in [`resolve_ethereum_state`](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/f46da0e09ca207b266ad0508fb1337e4b14c6ac2/crates/stateless-witness/src/lib.rs#L175), specifically the per-account [`get_rlp::<TrieAccount>`](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/f46da0e09ca207b266ad0508fb1337e4b14c6ac2/crates/stateless-witness/src/lib.rs#L196) call.

## How the error is produced

The MPT resolver does **not** error when a referenced node is absent from its store — it inserts an unresolved `Digest` placeholder and keeps going:

- [`resolver.rs#L57`](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/f46da0e09ca207b266ad0508fb1337e4b14c6ac2/crates/mpt/src/resolver.rs#L57) — `None => mpt.add_node(&NodeData::Digest(item))`

When asked to resolve a root hash that isn't in the node store, the result is therefore a trie whose root is a single `Digest` placeholder. The error only surfaces **later**, when traversal actually walks into that placeholder:

- [`trie.rs#L620`](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/f46da0e09ca207b266ad0508fb1337e4b14c6ac2/crates/mpt/src/trie.rs#L620) — `NodeData::Digest(digest) => Err(Error::NodeNotResolved(...))`

Note also that the existing sanity check at [`lib.rs#L187`](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/f46da0e09ca207b266ad0508fb1337e4b14c6ac2/crates/stateless-witness/src/lib.rs#L187), `assert_eq!(state_trie.hash(), state_root)`, passes **vacuously** in this case: a `Digest` node hashes to itself, so `state_trie.hash() == state_root` is trivially true even though the trie is empty. That's why the failure isn't caught early with a clear message.

## Root-cause analysis

I reconstructed the witness from the archived `.bin` file and inspected it. Findings for block 25180499:

| Property | Value |
| --- | --- |
| `parent_state_root` recorded in witness | `0x1004303c…069453d4` |
| Unresolved node reported by the error | `0x1004…53d4` — **identical** to `parent_state_root` |
| `execution_witness.state` node count | 16268 |
| Node hashing to `parent_state_root` present in `state`? | **No** |
| Node hashing to the post-state root present in `state`? | **No** |
| Root the 16268 nodes **actually** form | `0xfa4afe50…ac5ffe30` |
| Accounts that resolve cleanly under that root | **200/200 sampled, 0 unresolved** |

So the supplied state nodes are a **complete, self-consistent** account trie — just rooted at `0xfa4afe50…`, which matches **neither** the recorded `parent_state_root` (`0x1004…`) **nor** the post-state root. The state nodes and the `parent_state_root` come from two different snapshots.

### Where the two snapshots diverge

In the buggy version, the parent header and the parent state are fetched with two independent reads, both keyed by block *number*:

- [`lib.rs#L111-L114`](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/f46da0e09ca207b266ad0508fb1337e4b14c6ac2/crates/stateless-witness/src/lib.rs#L111-L114):

```rust
let parent_block   = provider.block_by_id(parent_block_number.into())?  // → parent_state_root
    .ok_or(...)?;
let state_provider = provider.state_by_block_id(parent_block_number.into())?;  // → witness state nodes
```

- `parent_state_root` is then taken from that header at [`lib.rs#L167`](https://github.com/axiom-crypto/openvm-reth-benchmark/blob/f46da0e09ca207b266ad0508fb1337e4b14c6ac2/crates/stateless-witness/src/lib.rs#L167).
- The state nodes come from Reth's `state_provider.witness(...)` ([reth v2.1.0 `historical.rs#L527`](https://github.com/paradigmxyz/reth/blob/v2.1.0/crates/storage/provider/src/providers/state/historical.rs#L527)), which builds a correct multiproof against whatever trie *that* provider resolves. Reth does its job correctly; it never cross-checks the multiproof root against the block header, so the mismatch passes through silently.

These two calls are **not** a consistent snapshot. They query a `block_number` against a live database at two different instants. If a reorg at the parent height commits between them, one read sees chain A and the other sees chain B, and the header/state pair becomes inconsistent.

## Fix

Two changes, both in `crates/stateless-witness/`.

### 1. Read parent header and parent state from one immutable snapshot

Key both reads off the **parent block hash** (`recovered_block.parent_hash()`) instead of the block number. A block hash is an immutable identity: the block with that hash has a fixed `state_root` and a fixed associated state, so the two reads can no longer disagree — regardless of concurrent reorgs. It also correctly proves the parent of *this* block rather than "whatever currently sits at height N-1".

```rust
let parent_hash = recovered_block.parent_hash();
let parent_header =
    provider.header(parent_hash)?.ok_or(WitnessError::ParentBlockNotFound(parent_hash))?;
let state_provider = provider.state_by_block_hash(parent_hash)?;
...
parent_state_root: parent_header.state_root(),
```

(`block_by_id` was only used to read `state_root`, so it's replaced by the lighter `header` lookup.)

### 2. Add an explicit parent-state-root guard

Replace the vacuous `assert_eq!` blind spot with an upfront check in `resolve_ethereum_state`: the witness **must** contain the trie node hashing to `state_root`. If it doesn't, fail loudly with the expected root instead of stubbing a `Digest` and surfacing later as an opaque "reached an unresolved node":

```rust
if !has_state_root_node {
    return Err(WitnessError::StateRootNodeMissing(state_root));
}
```

New error variant:

```rust
#[error(
    "witness is missing the state trie root node for parent state root {0}; the witness \
     `state` and `parent_state_root` describe different snapshots (e.g. a reorg during \
     witness generation)"
)]
StateRootNodeMissing(B256),
```

Towards INT-7761