### PR TITLE
chore: update benchmark openvm params

### DIFF
--- a/.github/workflows/reth-benchmark.yml
+++ b/.github/workflows/reth-benchmark.yml
@@ -3,24 +3,29 @@ run-name: "Reth Benchmark (block ${{ inputs.block_number || github.event.inputs.
 
 on:
   workflow_dispatch:
-    # github workflow dispatch inputs has 10 input limit...
-    # > you may only define up to 10 `inputs` for a `workflow_dispatch` event
     inputs:
       instance_family:
         type: string
         required: false
         description: The family of the instance, can be multiple ones concat with "+" e.g. g6+g5
         default: g6e.2xlarge
+      memory_allocator:
+        type: choice
+        required: false
+        description: Memory allocator to use
+        options:
+          - jemalloc
+          - mimalloc
+        default: jemalloc
       block_number:
         type: number
         required: false
         description: Block number to run the benchmark on
         default: 23992138
-      # app_log_blowup:
-      #   type: number
-      #   required: false
-      #   description: Application level log blowup
-      #   default: 1
+      app_log_blowup:
+        type: number
+        required: false
+        description: Application level log blowup
       leaf_log_blowup:
         type: number
         required: false
@@ -29,11 +34,10 @@ on:
         type: number
         required: false
         description: Internal level log blowup
-      # root_log_blowup:
-      #   type: number
-      #   required: false
-      #   description: Root level log blowup (only for e2e)
-      #   default: 3
+      root_log_blowup:
+        type: number
+        required: false
+        description: Root level log blowup
       mode:
         type: choice
         required: false
@@ -59,18 +63,15 @@ on:
       max_segment_length:
         type: number
         required: false
-        description: Max segment length for continuations
-        default: 4194304 # 2**22, but the main criteria should be segment_max_memory
+        description: Max segment length override for continuations
       segment_max_memory:
         type: string
         required: false
-        description: GPU memory soft limit for segmentation
-        default: "16106127360" # 15gb
+        description: GPU memory soft limit override for segmentation
       app_l_skip:
         type: number
         required: false
-        description: Log of univariate skip domain size
-        default: 4
+        description: Log of univariate skip domain size override
       use_tco:
         type: boolean
         required: false
@@ -85,16 +86,14 @@ on:
           - refresh
           - disabled
         default: use
-      # num_children_leaf:
-      #   type: number
-      #   required: false
-      #   description: Number of app proofs that leaf verifier aggregates
-      #   default: 1
-      # num_children_internal:
-      #   type: number
-      #   required: false
-      #   description: Number of proofs that internal verifier aggregates
-      #   default: 3
+      num_children_leaf:
+        type: number
+        required: false
+        description: Number of app proofs that leaf verifier aggregates
+      num_children_internal:
+        type: number
+        required: false
+        description: Number of proofs that internal verifier aggregates
   workflow_call:
     inputs:
       ref:
@@ -116,11 +115,10 @@ on:
         required: false
         description: Block number to run the benchmark on
         default: 23992138
-      # app_log_blowup:
-      #   type: number
-      #   required: false
-      #   description: Application level log blowup
-      #   default: 1
+      app_log_blowup:
+        type: number
+        required: false
+        description: Application level log blowup
       leaf_log_blowup:
         type: number
         required: false
@@ -129,11 +127,10 @@ on:
         type: number
         required: false
         description: Internal level log blowup (only for e2e)
-      # root_log_blowup:
-      #   type: number
-      #   required: false
-      #   description: Root level log blowup (only for e2e)
-      #   default: 3
+      root_log_blowup:
+        type: number
+        required: false
+        description: Root level log blowup
       mode:
         type: string
         required: false
@@ -147,32 +144,28 @@ on:
       max_segment_length:
         type: number
         required: false
-        description: Max segment length for continuations
-        default: 4194304 # 2**22, but the main criteria should be segment_max_memory
+        description: Max segment length override for continuations
       segment_max_memory:
         type: string
         required: false
-        default: "16106127360"
+        description: GPU memory soft limit override for segmentation
       app_l_skip:
         type: number
         required: false
-        description: Log of univariate skip domain size
-        default: 4
+        description: Log of univariate skip domain size override
       use_tco:
         type: boolean
         required: false
         description: Use TCO instead of AOT
         default: false
-      # num_children_leaf:
-      #   type: number
-      #   required: false
-      #   description: Number of app proofs that leaf verifier aggregates
-      #   default: 1
-      # num_children_internal:
-      #   type: number
-      #   required: false
-      #   description: Number of proofs that internal verifier aggregates
-      #   default: 3
+      num_children_leaf:
+        type: number
+        required: false
+        description: Number of app proofs that leaf verifier aggregates
+      num_children_internal:
+        type: number
+        required: false
+        description: Number of proofs that internal verifier aggregates
       tag:
         type: string
         required: false
@@ -246,11 +239,7 @@ jobs:
 
       - name: Display workflow inputs
         run: |
-          if [[ "${{ inputs.manual_call }}" == "true" ]]; then
-            echo "${{ toJSON(inputs) }}"
-          else
-            echo "${{ toJSON(github.event.inputs) }}"
-          fi
+          echo '${{ toJSON(inputs || github.event.inputs) }}'
 
       - name: Get current commit hash
         run: |
@@ -515,26 +504,61 @@ jobs:
           MODE=${{ inputs.mode || github.event.inputs.mode }}
           BLOCK_NUMBER=${{ inputs.block_number || github.event.inputs.block_number }}
           HOST_PROFILE=${{ steps.set-build-profiles.outputs.host_profile }}
+          OPTIONAL_ARGS=""
+          APP_LOG_BLOWUP="${{ inputs.app_log_blowup || github.event.inputs.app_log_blowup }}"
           LEAF_LOG_BLOWUP="${{ inputs.leaf_log_blowup || github.event.inputs.leaf_log_blowup }}"
           INTERNAL_LOG_BLOWUP="${{ inputs.internal_log_blowup || github.event.inputs.internal_log_blowup }}"
+          ROOT_LOG_BLOWUP="${{ inputs.root_log_blowup || github.event.inputs.root_log_blowup }}"
+          MAX_SEGMENT_LENGTH="${{ inputs.max_segment_length || github.event.inputs.max_segment_length }}"
+          SEGMENT_MAX_MEMORY="${{ inputs.segment_max_memory || github.event.inputs.segment_max_memory }}"
+          APP_L_SKIP="${{ inputs.app_l_skip || github.event.inputs.app_l_skip }}"
+          NUM_CHILDREN_LEAF="${{ inputs.num_children_leaf || github.event.inputs.num_children_leaf }}"
+          NUM_CHILDREN_INTERNAL="${{ inputs.num_children_internal || github.event.inputs.num_children_internal }}"
+          HELP_OUTPUT="$(COLUMNS=240 ./target/$HOST_PROFILE/${{ env.BIN_NAME }} --help)"
+          read_default() {
+            awk -v arg="$1" '$0 ~ arg { in_arg = 1; next } in_arg && /\[default:/ { gsub(/.*\[default: |].*/, ""); print; exit }' <<< "$HELP_OUTPUT"
+          }
+          DEFAULT_MAX_SEGMENT_LENGTH="$(read_default "--max-segment-length ")"
+          DEFAULT_SEGMENT_MAX_MEMORY="$(read_default "--segment-max-memory ")"
+          if [[ -z "$DEFAULT_MAX_SEGMENT_LENGTH" || -z "$DEFAULT_SEGMENT_MAX_MEMORY" ]]; then
+            echo "Failed to read segmentation defaults from ${{ env.BIN_NAME }} --help" >&2
+            exit 1
+          fi
+          RESOLVED_MAX_SEGMENT_LENGTH="${MAX_SEGMENT_LENGTH:-$DEFAULT_MAX_SEGMENT_LENGTH}"
+          RESOLVED_SEGMENT_MAX_MEMORY="${SEGMENT_MAX_MEMORY:-$DEFAULT_SEGMENT_MAX_MEMORY}"
+          echo "RESOLVED_MAX_SEGMENT_LENGTH=$RESOLVED_MAX_SEGMENT_LENGTH" >> "$GITHUB_ENV"
+          echo "RESOLVED_SEGMENT_MAX_MEMORY=$RESOLVED_SEGMENT_MAX_MEMORY" >> "$GITHUB_ENV"
+          if [[ -n $APP_LOG_BLOWUP ]]; then
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --app-log-blowup $APP_LOG_BLOWUP"
+          fi
           if [[ -n $LEAF_LOG_BLOWUP ]]; then
             OPTIONAL_ARGS="$OPTIONAL_ARGS --leaf-log-blowup $LEAF_LOG_BLOWUP"
           fi
           if [[ -n $INTERNAL_LOG_BLOWUP ]]; then
             OPTIONAL_ARGS="$OPTIONAL_ARGS --internal-log-blowup $INTERNAL_LOG_BLOWUP"
           fi
-          # TODO: make these configurable again when needed:
-          # OPTIONAL_ARGS="$OPTIONAL_ARGS --app-log-blowup <value>"
-          # OPTIONAL_ARGS="$OPTIONAL_ARGS --root-log-blowup <value>"
-          # OPTIONAL_ARGS="$OPTIONAL_ARGS --num-children-leaf <value>"
-          # OPTIONAL_ARGS="$OPTIONAL_ARGS --num-children-internal <value>"
+          if [[ -n $ROOT_LOG_BLOWUP ]]; then
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --root-log-blowup $ROOT_LOG_BLOWUP"
+          fi
+          if [[ -n $MAX_SEGMENT_LENGTH ]]; then
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --max-segment-length $MAX_SEGMENT_LENGTH"
+          fi
+          if [[ -n $SEGMENT_MAX_MEMORY ]]; then
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --segment-max-memory $SEGMENT_MAX_MEMORY"
+          fi
+          if [[ -n $APP_L_SKIP ]]; then
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --app-l-skip $APP_L_SKIP"
+          fi
+          if [[ -n $NUM_CHILDREN_LEAF ]]; then
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --num-children-leaf $NUM_CHILDREN_LEAF"
+          fi
+          if [[ -n $NUM_CHILDREN_INTERNAL ]]; then
+            OPTIONAL_ARGS="$OPTIONAL_ARGS --num-children-internal $NUM_CHILDREN_INTERNAL"
+          fi
           cat > run_benchmark.sh <<EOF
           #!/bin/bash
           /usr/bin/time -v ./target/$HOST_PROFILE/${{ env.BIN_NAME }} \
             --mode $MODE --block-number $BLOCK_NUMBER $PROVIDER_ARGS $CACHE_ARGS \
-            --max-segment-length ${{ inputs.max_segment_length || github.event.inputs.max_segment_length }} \
-            --segment-max-memory ${{ inputs.segment_max_memory || github.event.inputs.segment_max_memory }} \
-            --app-l-skip ${{ inputs.app_l_skip || github.event.inputs.app_l_skip || 4 }} \
             $OPTIONAL_ARGS
           EOF
           chmod +x run_benchmark.sh
@@ -542,9 +566,8 @@ jobs:
       - name: Run benchmark
         id: run-benchmark
         run: |
-          MAX_MEMORY=${{ inputs.segment_max_memory || github.event.inputs.segment_max_memory }}
           export VPMM_PAGE_SIZE=$((4<<20))
-          export VPMM_PAGES=$((MAX_MEMORY / VPMM_PAGE_SIZE))
+          export VPMM_PAGES=$((RESOLVED_SEGMENT_MAX_MEMORY / VPMM_PAGE_SIZE))
           export JEMALLOC_SYS_WITH_MALLOC_CONF=${JEMALLOC_SYS_WITH_MALLOC_CONF}
           export RUST_LOG="info,p3_=warn"
           export OUTPUT_PATH=${METRIC_PATH}
@@ -687,7 +710,7 @@ jobs:
           source openvm/ci/scripts/utils.sh
 
           add_metadata $MD_PATH \
-            ${{ inputs.max_segment_length || github.event.inputs.max_segment_length }} \
+            $RESOLVED_MAX_SEGMENT_LENGTH \
             ${{ inputs.instance_family || github.event.inputs.instance_family }} \
             ${{ inputs.memory_allocator || github.event.inputs.memory_allocator || 'jemalloc' }} \
             $COMMIT_URL \
@@ -776,8 +799,10 @@ jobs:
 
       - name: Commit to gh-pages branch
         working-directory: gh-pages
+        env:
+          REF_NAME: ${{ github.head_ref || github.ref }}
         run: |
-          GH_PAGES_PATH="benchmarks-dispatch/${{ github.head_ref || github.ref }}"
+          GH_PAGES_PATH="benchmarks-dispatch/${REF_NAME}"
           echo "GH_PAGES_PATH=${GH_PAGES_PATH}" >> $GITHUB_ENV
           mkdir -p ${GH_PAGES_PATH}
           s5cmd cp $S3_MD_PATH "${GH_PAGES_PATH}/${METRIC_NAME}.md"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.0.1",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1160,7 +1160,7 @@ checksum = "a29980e69119444ed26b75e7ee5bed2043870f904a64318297e55800db686564"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "reqwest 0.13.3",
  "serde_json",
  "tower",
@@ -5326,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6484,7 +6484,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "bytemuck",
  "num-bigint",
@@ -6497,7 +6497,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6531,7 +6531,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6541,7 +6541,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "halo2curves-axiom 0.7.2",
  "num-bigint",
@@ -6557,7 +6557,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -6569,7 +6569,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-algebra-guest",
  "openvm-instructions",
@@ -6583,7 +6583,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6610,7 +6610,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-platform",
  "strum_macros 0.26.4",
@@ -6619,7 +6619,7 @@ dependencies = [
 [[package]]
 name = "openvm-bigint-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-bigint-guest",
  "openvm-instructions",
@@ -6634,7 +6634,7 @@ dependencies = [
 [[package]]
 name = "openvm-build"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cargo_metadata 0.18.1",
  "eyre",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "abi_stable",
  "backtrace",
@@ -6701,7 +6701,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6712,7 +6712,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -6732,7 +6732,7 @@ dependencies = [
 [[package]]
 name = "openvm-circuit-primitives-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
@@ -6743,7 +6743,7 @@ dependencies = [
 [[package]]
 name = "openvm-codec-derive"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#33727d1ad90d08a888698f0107eed955dd8603d5"
 dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro2",
@@ -6754,7 +6754,7 @@ dependencies = [
 [[package]]
 name = "openvm-continuations"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -6783,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "openvm-cpu-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#33727d1ad90d08a888698f0107eed955dd8603d5"
 dependencies = [
  "cfg-if",
  "derive-new 0.7.0",
@@ -6808,7 +6808,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#33727d1ad90d08a888698f0107eed955dd8603d5"
 dependencies = [
  "derive-new 0.7.0",
  "getset",
@@ -6835,7 +6835,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-builder"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#33727d1ad90d08a888698f0107eed955dd8603d5"
 dependencies = [
  "cc",
  "glob",
@@ -6844,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "openvm-cuda-common"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#33727d1ad90d08a888698f0107eed955dd8603d5"
 dependencies = [
  "bytesize",
  "ctor",
@@ -6858,7 +6858,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6868,7 +6868,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cfg-if",
  "dashmap",
@@ -6902,7 +6902,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-custom-insn",
  "strum_macros 0.26.4",
@@ -6911,7 +6911,7 @@ dependencies = [
 [[package]]
 name = "openvm-deferral-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "eyre",
  "openvm-deferral-guest",
@@ -6927,7 +6927,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "blstrs",
  "cfg-if",
@@ -6961,7 +6961,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -6980,7 +6980,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -6990,7 +6990,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-ecc-guest",
  "openvm-instructions",
@@ -7004,7 +7004,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "backtrace",
  "derive-new 0.6.0",
@@ -7021,7 +7021,7 @@ dependencies = [
 [[package]]
 name = "openvm-instructions-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7030,7 +7030,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-keccak256-guest",
  "spin 0.10.0",
@@ -7040,7 +7040,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "derive-new 0.6.0",
  "derive_more 1.0.0",
@@ -7068,7 +7068,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-platform",
 ]
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7106,7 +7106,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "syn 2.0.102",
 ]
@@ -7114,7 +7114,7 @@ dependencies = [
 [[package]]
 name = "openvm-mod-circuit-builder"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "itertools 0.14.0",
  "num-bigint",
@@ -7172,7 +7172,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "group 0.13.0",
  "hex-literal",
@@ -7195,7 +7195,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7227,7 +7227,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "blstrs",
  "halo2curves-axiom 0.7.2",
@@ -7248,7 +7248,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-instructions",
  "openvm-pairing-guest",
@@ -7261,7 +7261,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "libm",
  "openvm-custom-insn",
@@ -7271,7 +7271,7 @@ dependencies = [
 [[package]]
 name = "openvm-poseidon2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "derivative",
  "lazy_static",
@@ -7289,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "derive-new 0.6.0",
  "eyre",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "openvm-recursion-circuit-derive"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "quote",
  "syn 2.0.102",
@@ -7437,7 +7437,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32-adapters"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "derive-new 0.6.0",
  "itertools 0.14.0",
@@ -7454,7 +7454,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7482,7 +7482,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -7492,7 +7492,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7508,7 +7508,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "alloy-sol-types",
  "bitcode",
@@ -7552,7 +7552,7 @@ dependencies = [
 [[package]]
 name = "openvm-sdk-config"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "bon",
  "cfg-if",
@@ -7587,7 +7587,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm",
  "openvm-sha2-guest",
@@ -7597,7 +7597,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-air"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "ndarray",
  "num_enum",
@@ -7611,7 +7611,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7640,7 +7640,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-platform",
 ]
@@ -7648,7 +7648,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-instructions",
  "openvm-instructions-derive",
@@ -7662,7 +7662,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-backend"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#33727d1ad90d08a888698f0107eed955dd8603d5"
 dependencies = [
  "cfg-if",
  "derivative",
@@ -7697,7 +7697,7 @@ dependencies = [
 [[package]]
 name = "openvm-stark-sdk"
 version = "2.0.0-alpha"
-source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#12c8f9eebf9622972244473d9058ca6f560033eb"
+source = "git+https://github.com/openvm-org/stark-backend.git?branch=develop-v2#33727d1ad90d08a888698f0107eed955dd8603d5"
 dependencies = [
  "dashmap",
  "derive-new 0.7.0",
@@ -7783,7 +7783,7 @@ dependencies = [
 [[package]]
 name = "openvm-static-verifier"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "halo2-base",
  "itertools 0.14.0",
@@ -7807,7 +7807,7 @@ dependencies = [
 [[package]]
 name = "openvm-transpiler"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "elf",
  "eyre",
@@ -7822,7 +7822,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-circuit"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "cfg-if",
  "derive-new 0.6.0",
@@ -7852,7 +7852,7 @@ dependencies = [
 [[package]]
 name = "openvm-verify-stark-host"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "bitcode",
  "eyre",
@@ -7891,7 +7891,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -8682,7 +8682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.102",

--- a/bin/reth-benchmark/README.md
+++ b/bin/reth-benchmark/README.md
@@ -164,12 +164,13 @@ openvm-prof --json-paths metrics.json
 The benchmark command accepts additional arguments that can be used to configure the benchmark. **These are low-level and require knowledge of the proof system.** They include:
 
 - `--app-log-blowup`: Set the blowup factor for the App VM proofs (default: 1)
-- `--leaf-log-blowup`: Set the blowup factor for the leaf aggregation proofs (default: 1)
-- `--internal-log-blowup`: Set the blowup factor for the internal non-leaf aggregation proofs (default: 2)
-- `--root-log-blowup`: Set the blowup factor for the root STARK aggregation proof (default: 3)
+- `--app-l-skip`: Set the log of univariate skip domain size (default: 4)
+- `--leaf-log-blowup`: Set the blowup factor for the leaf aggregation proofs (default: 2)
+- `--internal-log-blowup`: Set the blowup factor for the internal non-leaf aggregation proofs (default: 3)
+- `--root-log-blowup`: Set the blowup factor for the root STARK aggregation proof (default: 4)
 - `--max-segment-length`: Set the threshold number of cycles before the execution should segment (default: `2 ** 22`)
-- `--segment-max-cells`: Set the maximum number of cells per segment
-- `--num-children-leaf`: Set the number of children for leaf aggregation (default: 1)
+- `--segment-max-memory`: Set the maximum metered memory per segment
+- `--num-children-leaf`: Set the number of children for leaf aggregation (default: 4)
 - `--num-children-internal`: Set the number of children for internal aggregation (default: 3)
 - `--preimage-cache-nibbles`: Set the preimage cache nibbles (default: 7)
 

--- a/bin/reth-benchmark/src/lib.rs
+++ b/bin/reth-benchmark/src/lib.rs
@@ -6,28 +6,40 @@ use alloy_provider::RootProvider;
 use alloy_rpc_client::RpcClient;
 use alloy_transport::layers::RetryBackoffLayer;
 use clap::Parser;
-use openvm_circuit::arch::{instructions::exe::VmExe, *};
+use eyre::Result;
+use openvm_circuit::arch::{
+    execution_mode::metered::segment_ctx::{DEFAULT_MAX_MEMORY, DEFAULT_MAX_TRACE_HEIGHT},
+    instructions::exe::VmExe,
+    verify_segments, VmCircuitConfig,
+};
 use openvm_rpc_proxy::{RpcExecutor, DEFAULT_PREIMAGE_CACHE_NIBBLES};
 use openvm_sdk::{
     config::{
-        AggregationSystemParams, AppConfig, DEFAULT_APP_LOG_BLOWUP, DEFAULT_APP_L_SKIP,
-        DEFAULT_INTERNAL_LOG_BLOWUP, DEFAULT_LEAF_LOG_BLOWUP,
+        AggregationSystemParams, AggregationTreeConfig, AppConfig, DEFAULT_APP_LOG_BLOWUP,
+        DEFAULT_APP_L_SKIP, DEFAULT_INTERNAL_LOG_BLOWUP, DEFAULT_LEAF_LOG_BLOWUP,
+        DEFAULT_ROOT_LOG_BLOWUP,
     },
     fs::{read_object_from_file, write_object_to_file},
     Sdk, SC,
 };
 use openvm_sdk_config::{SdkVmConfig, TranspilerConfig};
+#[cfg(feature = "evm-verify")]
+use openvm_stark_sdk::config::root_params_with_100_bits_security;
+#[cfg(feature = "evm-verify")]
+use openvm_stark_sdk::openvm_stark_backend::codec::Decode;
 use openvm_stark_sdk::{
     bench::run_with_metric_collection,
     config::{
-        app_params_with_100_bits_security,
-        baby_bear_poseidon2::{D_EF, F},
+        app_params_with_100_bits_security, baby_bear_poseidon2::F,
+        internal_params_with_100_bits_security, leaf_params_with_100_bits_security,
+        MAX_APP_LOG_STACKED_HEIGHT, SECURITY_BITS_TARGET,
     },
     openvm_stark_backend::{
         air_builders::symbolic::{SymbolicExpressionDag, SymbolicExpressionNode},
-        codec::{Decode, Encode},
+        codec::Encode,
         keygen::types::MultiStarkProvingKey,
         p3_field::PrimeCharacteristicRing,
+        SystemParams,
     },
 };
 use openvm_stateless_executor::{
@@ -43,8 +55,6 @@ use tracing::{info, info_span};
 
 mod cli;
 use cli::ProviderArgs;
-
-pub const DEFAULT_LOG_STACKED_HEIGHT: usize = 24;
 
 /// Enum representing the execution mode of the host executable.
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -183,13 +193,20 @@ pub struct BenchmarkCli {
     #[arg(long, default_value_t = DEFAULT_INTERNAL_LOG_BLOWUP)]
     pub internal_log_blowup: usize,
 
+    /// Root level log blowup
+    #[arg(long, default_value_t = DEFAULT_ROOT_LOG_BLOWUP)]
+    pub root_log_blowup: usize,
+
+    #[command(flatten)]
+    pub agg_tree_config: AggregationTreeConfig,
+
     /// Max trace height per chip in segment for continuations
-    #[arg(long, alias = "max_segment_length")]
-    pub max_segment_length: Option<u32>,
+    #[arg(long, alias = "max_segment_length", default_value_t = DEFAULT_MAX_TRACE_HEIGHT)]
+    pub max_segment_length: u32,
 
     /// Total cells used in all chips in segment for continuations
-    #[arg(long)]
-    pub segment_max_memory: Option<usize>,
+    #[arg(long, default_value_t = DEFAULT_MAX_MEMORY)]
+    pub segment_max_memory: usize,
 }
 
 pub fn reth_vm_config() -> SdkVmConfig {
@@ -204,25 +221,47 @@ pub fn reth_vm_config() -> SdkVmConfig {
 
 const VM_MAX_CONSTRAINT_DEGREE: usize = 4;
 
-pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) -> eyre::Result<()> {
+fn override_system_params(
+    params: SystemParams,
+    log_blowup: usize,
+    l_skip: usize,
+) -> Result<SystemParams> {
+    let log_stacked_height = params.log_stacked_height();
+    if l_skip > log_stacked_height {
+        eyre::bail!("l_skip ({l_skip}) must be <= log_stacked_height ({log_stacked_height})");
+    }
+
+    let whir = params.whir().clone();
+    Ok(SystemParams::new(
+        log_blowup,
+        l_skip,
+        log_stacked_height - l_skip,
+        params.w_stack,
+        whir.log_final_poly_len(log_stacked_height),
+        whir.folding_pow_bits,
+        whir.mu_pow_bits,
+        whir.proximity,
+        SECURITY_BITS_TARGET,
+        params.logup,
+        params.max_constraint_degree,
+    ))
+}
+
+fn override_log_blowup(params: SystemParams, log_blowup: usize) -> Result<SystemParams> {
+    let l_skip = params.l_skip;
+    override_system_params(params, log_blowup, l_skip)
+}
+
+pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) -> Result<()> {
     // Initialize the environment variables.
     dotenv::dotenv().ok();
-
-    let app_log_blowup = args.benchmark.app_log_blowup;
-    let app_l_skip = args.benchmark.app_l_skip;
 
     #[cfg(feature = "cuda")]
     println!("CUDA Backend Enabled");
 
     let mut vm_config = reth_vm_config();
-    if let Some(max_trace_height) = args.benchmark.max_segment_length {
-        vm_config.as_mut().segmentation_config.limits.set_max_trace_height(max_trace_height);
-    }
-    if let Some(max_memory) = args.benchmark.segment_max_memory {
-        vm_config.as_mut().segmentation_config.limits.set_max_memory(max_memory);
-    }
-
-    vm_config.as_mut().segmentation_config.main_cell_weight = 1 + (1 << app_log_blowup);
+    vm_config.as_mut().segmentation_limits.set_max_trace_height(args.benchmark.max_segment_length);
+    vm_config.as_mut().segmentation_limits.set_max_memory(args.benchmark.segment_max_memory);
 
     for (air_idx, air) in VmCircuitConfig::<SC>::create_airs(&vm_config)?.into_airs().enumerate() {
         tracing::debug!("air_idx={air_idx} | {}", air.name());
@@ -230,11 +269,27 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
 
     let transpiler = vm_config.transpiler().clone();
 
-    let app_params = app_params_with_100_bits_security(DEFAULT_LOG_STACKED_HEIGHT);
+    let app_params = override_system_params(
+        app_params_with_100_bits_security(MAX_APP_LOG_STACKED_HEIGHT),
+        args.benchmark.app_log_blowup,
+        args.benchmark.app_l_skip,
+    )?;
 
     // Setup: this can all be done once before receiving proof input
     let app_config = AppConfig::new(vm_config, app_params);
-    let agg_params = AggregationSystemParams::default();
+    let agg_params = AggregationSystemParams {
+        leaf: override_log_blowup(
+            leaf_params_with_100_bits_security(),
+            args.benchmark.leaf_log_blowup,
+        )?,
+        internal: override_log_blowup(
+            internal_params_with_100_bits_security(),
+            args.benchmark.internal_log_blowup,
+        )?,
+    };
+    #[cfg(feature = "evm-verify")]
+    let root_params =
+        override_log_blowup(root_params_with_100_bits_security(), args.benchmark.root_log_blowup)?;
 
     // Resolve key paths: explicit flag wins; otherwise fall back to <output_dir>/<name>.pk
     // if the file exists. The chain agg->app and root->agg->app is enforced by the builder,
@@ -248,7 +303,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
         p.exists().then_some(p)
     });
 
-    let mut sdk_builder = Sdk::builder();
+    let mut sdk_builder = Sdk::builder().agg_tree_config(args.benchmark.agg_tree_config);
 
     if let Some(p) = app_pk_path {
         info!("Loading app proving key from {}", p.display());
@@ -273,6 +328,8 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
             info!("Loading root proving key from {}", root_pk_path.display());
             let root_pk = read_object_from_file(&root_pk_path)?;
             sdk_builder = sdk_builder.root_pk(root_pk);
+        } else {
+            sdk_builder = sdk_builder.root_params(root_params);
         }
     }
 
@@ -410,7 +467,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     let stdin = vec![encoded_stateless_input].into();
 
     run_with_metric_collection("OUTPUT_PATH", move || {
-        info_span!("reth-block", block_number = block_number).in_scope(|| -> eyre::Result<()> {
+        info_span!("reth-block", block_number = block_number).in_scope(|| -> Result<()> {
             match args.mode {
                 BenchMode::Execute => {
                     let public_values = info_span!("sdk.execute", group = program_name)
@@ -420,7 +477,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
                     println!("BENCH_BLOCK_HASH={block_hash}");
                 }
                 BenchMode::ExecuteMetered => {
-                    let (public_values, segments) =
+                    let (public_values, _segments) =
                         info_span!("sdk.execute_metered", group = program_name)
                             .in_scope(|| sdk.execute_metered(exe, stdin))?;
                     let block_hash = hex::encode(&public_values);
@@ -562,7 +619,7 @@ pub async fn run_reth_benchmark(args: HostArgs, openvm_client_eth_elf: &[u8]) ->
     Ok(())
 }
 
-fn dump_air_stats(sdk: &Sdk, output_path: &PathBuf) -> eyre::Result<()> {
+fn dump_air_stats(sdk: &Sdk, output_path: &PathBuf) -> Result<()> {
     let (app_pk, _app_vk) = sdk.app_keygen();
     let mut file = fs::File::create(output_path)?;
     writeln!(
@@ -579,11 +636,7 @@ fn dump_air_stats(sdk: &Sdk, output_path: &PathBuf) -> eyre::Result<()> {
     Ok(())
 }
 
-fn dump_pk_stats(
-    label: &str,
-    pk: &MultiStarkProvingKey<SC>,
-    file: &mut fs::File,
-) -> eyre::Result<()> {
+fn dump_pk_stats(label: &str, pk: &MultiStarkProvingKey<SC>, file: &mut fs::File) -> Result<()> {
     for (air_idx, air_pk) in pk.per_air.iter().enumerate() {
         let dag = &air_pk.vk.symbolic_constraints.constraints;
         let mono_start = Instant::now();
@@ -655,7 +708,7 @@ fn try_load_input_from_cache(
     cache_dir: Option<&PathBuf>,
     chain_id: u64,
     block_number: u64,
-) -> eyre::Result<Option<StatelessExecutorInput>> {
+) -> Result<Option<StatelessExecutorInput>> {
     Ok(if let Some(cache_dir) = cache_dir {
         let cache_path = cache_dir.join(format!("input/{chain_id}/{block_number}.bin"));
 
@@ -674,7 +727,7 @@ fn try_load_input_from_cache(
     })
 }
 
-fn try_load_input_from_path(path: &PathBuf) -> eyre::Result<StatelessExecutorInput> {
+fn try_load_input_from_path(path: &PathBuf) -> Result<StatelessExecutorInput> {
     let ext = path.extension().and_then(|s| s.to_str()).unwrap_or("");
     if ext.eq_ignore_ascii_case("json") {
         let s = std::fs::read_to_string(path)?;

--- a/bin/stateless-guest/Cargo.lock
+++ b/bin/stateless-guest/Cargo.lock
@@ -2008,7 +2008,7 @@ dependencies = [
 [[package]]
 name = "k256"
 version = "0.13.4"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2310,7 +2310,7 @@ dependencies = [
 [[package]]
 name = "openvm"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "bytemuck",
  "getrandom 0.2.17",
@@ -2325,7 +2325,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-complex-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2335,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "halo2curves-axiom",
  "num-bigint",
@@ -2351,7 +2351,7 @@ dependencies = [
 [[package]]
 name = "openvm-algebra-moduli-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "num-bigint",
  "num-prime",
@@ -2373,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "openvm-custom-insn"
 version = "0.1.0"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2383,7 +2383,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
@@ -2402,7 +2402,7 @@ dependencies = [
 [[package]]
 name = "openvm-ecc-sw-macros"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-macros-common",
  "quote",
@@ -2412,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-keccak256-guest",
  "spin 0.10.0",
@@ -2422,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "openvm-keccak256-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-platform",
 ]
@@ -2446,7 +2446,7 @@ dependencies = [
 [[package]]
 name = "openvm-macros-common"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "syn 2.0.114",
 ]
@@ -2469,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "group",
  "hex-literal",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "openvm-pairing-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "hex-literal",
  "itertools 0.14.0",
@@ -2511,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "openvm-platform"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "critical-section",
  "embedded-alloc",
@@ -2541,7 +2541,7 @@ dependencies = [
 [[package]]
 name = "openvm-rv32im-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-custom-insn",
  "p3-field",
@@ -2551,7 +2551,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm",
  "openvm-sha2-guest",
@@ -2561,7 +2561,7 @@ dependencies = [
 [[package]]
 name = "openvm-sha2-guest"
 version = "2.0.0-beta.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "openvm-platform",
 ]
@@ -2619,7 +2619,7 @@ dependencies = [
 [[package]]
 name = "p256"
 version = "0.13.2"
-source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#bf4cfbf42eaa9c1c0a1298a8a93915089aa07f42"
+source = "git+https://github.com/openvm-org/openvm.git?branch=develop-v2.0.0-rc.2#3f897bcacec733f71d2b9d9ca9df83b245f216b1"
 dependencies = [
  "ecdsa",
  "elliptic-curve",

--- a/run.sh
+++ b/run.sh
@@ -9,7 +9,15 @@
 #   --profile <PROFILE> Set the Cargo build profile (default: profiling)
 #                       Valid profiles: dev, release, profiling
 #   --block <N>         Set the block number to prove (default: 23992138)
+#   --app-log-blowup <N>
 #   --app-l-skip <N>    Log of univariate skip domain size (default: 4)
+#   --leaf-log-blowup <N>
+#   --internal-log-blowup <N>
+#   --root-log-blowup <N>
+#   --num-children-leaf <N>
+#   --num-children-internal <N>
+#   --max-segment-length <N>
+#   --segment-max-memory <N>
 #   --cuda              Force CUDA acceleration (auto-detected if nvidia-smi available)
 #   --tco               Use TCO instead of AOT (default is AOT on x86_64)
 #   --perf              Run with perf + samply host profiling and upload to Firefox Profiler
@@ -87,12 +95,36 @@ while [[ $# -gt 0 ]]; do
             BLOCK_NUMBER_OVERRIDE="$2"
             shift 2
             ;;
+        --max-segment-length)
+            MAX_SEGMENT_LENGTH="$2"
+            shift 2
+            ;;
+        --segment-max-memory)
+            SEGMENT_MAX_MEMORY="$2"
+            shift 2
+            ;;
+        --app-log-blowup)
+            APP_LOG_BLOWUP="$2"
+            shift 2
+            ;;
         --leaf-log-blowup)
             LEAF_LOG_BLOWUP="$2"
             shift 2
             ;;
         --internal-log-blowup)
             INTERNAL_LOG_BLOWUP="$2"
+            shift 2
+            ;;
+        --root-log-blowup)
+            ROOT_LOG_BLOWUP="$2"
+            shift 2
+            ;;
+        --num-children-leaf)
+            NUM_CHILDREN_LEAF="$2"
+            shift 2
+            ;;
+        --num-children-internal)
+            NUM_CHILDREN_INTERNAL="$2"
             shift 2
             ;;
         --app-l-skip)
@@ -214,8 +246,6 @@ BLOCK_NUMBER="${BLOCK_NUMBER_OVERRIDE:-23992138}"
 # switch to +nightly-2026-01-18 if using tco
 TOOLCHAIN="+nightly-2026-01-18" # "+stable"
 BIN_NAME="openvm-reth-benchmark"
-MAX_SEGMENT_LENGTH=$((1 << 22))
-segment_max_memory=$((15 << 30))
 export VPMM_PAGE_SIZE=$((4 << 20))
 if [[ -z "${VPMM_PAGES:-}" ]] && [[ "$MODE" == "prove-stark" || "$MODE" == "prove-app" || "$MODE" == "prove-evm" ]]; then
     export VPMM_PAGES=$((16 << 8)) # start with 16GB
@@ -285,6 +315,10 @@ fi
 BIN=$REPO_ROOT/target/$TARGET_DIR/$BIN_NAME
 
 CONFIG_ARGS=""
+if [[ -n $APP_LOG_BLOWUP ]]
+then
+    CONFIG_ARGS="$CONFIG_ARGS --app-log-blowup ${APP_LOG_BLOWUP}"
+fi
 if [[ -n $LEAF_LOG_BLOWUP ]]
 then
     CONFIG_ARGS="$CONFIG_ARGS --leaf-log-blowup ${LEAF_LOG_BLOWUP}"
@@ -297,14 +331,32 @@ if [[ -n $APP_L_SKIP ]]
 then
     CONFIG_ARGS="$CONFIG_ARGS --app-l-skip ${APP_L_SKIP}"
 fi
+if [[ -n $ROOT_LOG_BLOWUP ]]
+then
+    CONFIG_ARGS="$CONFIG_ARGS --root-log-blowup ${ROOT_LOG_BLOWUP}"
+fi
+if [[ -n $NUM_CHILDREN_LEAF ]]
+then
+    CONFIG_ARGS="$CONFIG_ARGS --num-children-leaf ${NUM_CHILDREN_LEAF}"
+fi
+if [[ -n $NUM_CHILDREN_INTERNAL ]]
+then
+    CONFIG_ARGS="$CONFIG_ARGS --num-children-internal ${NUM_CHILDREN_INTERNAL}"
+fi
 if [[ -n $PROOF_CACHE ]]
 then
     CONFIG_ARGS="$CONFIG_ARGS --proof-cache ${PROOF_CACHE}"
 fi
+if [[ -n $MAX_SEGMENT_LENGTH ]]
+then
+    CONFIG_ARGS="$CONFIG_ARGS --max-segment-length ${MAX_SEGMENT_LENGTH}"
+fi
+if [[ -n $SEGMENT_MAX_MEMORY ]]
+then
+    CONFIG_ARGS="$CONFIG_ARGS --segment-max-memory ${SEGMENT_MAX_MEMORY}"
+fi
 
 BIN_ARGS="--mode $MODE \
---max-segment-length $MAX_SEGMENT_LENGTH \
---segment-max-memory $segment_max_memory \
 $CONFIG_ARGS"
 
 if [ "$MODE" != "generate-vm-vkey" ]; then
@@ -313,10 +365,6 @@ if [ "$MODE" != "generate-vm-vkey" ]; then
 --rpc-url $RPC_1 \
 --cache-dir rpc-cache"
 fi
-# TODO: aggregation tree (internal nodes)
-# --num-children-leaf 1 \
-# --num-children-internal 3
-
 export RUST_LOG="info,p3_=warn"
 
 echo "Run command:"

--- a/server/prove_block.sh
+++ b/server/prove_block.sh
@@ -10,14 +10,8 @@ S3_PREFIX="${S3_PREFIX:-proofs/testing}"
 BIN_PATH="${OVM_BIN:-/usr/local/bin/openvm-reth-benchmark}"
 JOBS_DIR="${JOBS_DIR:-/app/jobs}"
 MODE="${MODE:-prove-stark}"
-APP_LOG_BLOWUP="${APP_LOG_BLOWUP:-1}"
-LEAF_LOG_BLOWUP="${LEAF_LOG_BLOWUP:-1}"
-INTERNAL_LOG_BLOWUP="${INTERNAL_LOG_BLOWUP:-2}"
-ROOT_LOG_BLOWUP="${ROOT_LOG_BLOWUP:-3}"
-MAX_SEGMENT_LENGTH="${MAX_SEGMENT_LENGTH:-4194304}"
-SEGMENT_MAX_CELLS="${SEGMENT_MAX_CELLS:-1200000000}"
 VPMM_PAGE_SIZE=$((4 << 20))
-VPMM_PAGES=$((12 * $MAX_SEGMENT_LENGTH/ $VPMM_PAGE_SIZE))
+VPMM_PAGES="${VPMM_PAGES:-$((16 << 8))}"
 
 if [[ $# -lt 1 ]]; then
   echo "[prove_block.sh] Usage: $0 <proof_uuid>" >&2
@@ -63,20 +57,44 @@ PROOF_JSON="$job_dir/proof.json"
 
 OUTPUT_PATH="$job_dir/metrics.json"
 
-"$BIN_PATH" \
+args=(
   --mode "$MODE" \
   --block-number 1234 \
   --input-path "$INPUT_PATH" \
-  --app-log-blowup "$APP_LOG_BLOWUP" \
-  --leaf-log-blowup "$LEAF_LOG_BLOWUP" \
-  --internal-log-blowup "$INTERNAL_LOG_BLOWUP" \
-  --root-log-blowup "$ROOT_LOG_BLOWUP" \
-  --max-segment-length "$MAX_SEGMENT_LENGTH" \
-  --segment-max-cells "$SEGMENT_MAX_CELLS" \
   --output-dir "$job_dir" \
   --app-pk-path /app/app_pk \
-  --agg-pk-path /app/agg_pk \
-  --skip-comparison
+  --agg-pk-path /app/agg_pk
+)
+
+if [[ -n "${APP_LOG_BLOWUP:-}" ]]; then
+  args+=(--app-log-blowup "$APP_LOG_BLOWUP")
+fi
+if [[ -n "${APP_L_SKIP:-}" ]]; then
+  args+=(--app-l-skip "$APP_L_SKIP")
+fi
+if [[ -n "${LEAF_LOG_BLOWUP:-}" ]]; then
+  args+=(--leaf-log-blowup "$LEAF_LOG_BLOWUP")
+fi
+if [[ -n "${INTERNAL_LOG_BLOWUP:-}" ]]; then
+  args+=(--internal-log-blowup "$INTERNAL_LOG_BLOWUP")
+fi
+if [[ -n "${ROOT_LOG_BLOWUP:-}" ]]; then
+  args+=(--root-log-blowup "$ROOT_LOG_BLOWUP")
+fi
+if [[ -n "${NUM_CHILDREN_LEAF:-}" ]]; then
+  args+=(--num-children-leaf "$NUM_CHILDREN_LEAF")
+fi
+if [[ -n "${NUM_CHILDREN_INTERNAL:-}" ]]; then
+  args+=(--num-children-internal "$NUM_CHILDREN_INTERNAL")
+fi
+if [[ -n "${MAX_SEGMENT_LENGTH:-}" ]]; then
+  args+=(--max-segment-length "$MAX_SEGMENT_LENGTH")
+fi
+if [[ -n "${SEGMENT_MAX_MEMORY:-}" ]]; then
+  args+=(--segment-max-memory "$SEGMENT_MAX_MEMORY")
+fi
+
+"$BIN_PATH" "${args[@]}"
 status=$?
 
 end_ts_ms=$(date +%s%3N)


### PR DESCRIPTION
Updates the reth benchmark to use the current OpenVM parameter surfaces and avoid duplicating defaults in scripts/workflows.

Changes:
- Refreshes OpenVM/stark-backend lockfile revisions.
- Sources benchmark defaults from OpenVM/OpenVM SDK constants where available, including segmentation limits and proof-system blowup parameters.
- Adds CLI support for root log blowup and SDK aggregation tree config (`--num-children-leaf`, `--num-children-internal`).
- Rebuilds app, leaf, internal, and root system params from the selected CLI values while preserving the 100-bit security target.
- Uses the flattened `segmentation_limits` config and removes the old benchmark-side `main_cell_weight` override.
- Makes workflow/script overrides optional so unset values use the benchmark binary defaults.
- Exposes the proof-system and aggregation knobs as workflow inputs now that `workflow_dispatch` supports enough inputs.
- Resolves max segment length and segment memory defaults from `openvm-reth-benchmark --help`, then records numeric metadata for analysis instead of `default`.
- Updates local/server run scripts to pass only explicitly configured benchmark parameters.
- Updates benchmark docs for the current parameter names and defaults.

Validation:
- `cargo fmt`
- `cargo check -p openvm-reth-benchmark --no-default-features`
- `cargo check -p openvm-reth-benchmark --no-default-features --features evm-verify`
- `actionlint .github/workflows/reth-benchmark.yml`
- YAML parse for `.github/workflows/reth-benchmark.yml`
- `bash -n run.sh`
- `bash -n server/prove_block.sh`
- `git diff --check`

Note: clippy with `-D warnings` still fails on existing `openvm-mpt` dead-code warnings unrelated to this PR.